### PR TITLE
fix(jsonc-parser): do not trim empty lines by JSONC formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
-​# Change Log
+# Change Log
 
-​## 1.3.20
-​​​​​​
-### Fixed​
+## 1.3.20
 
-- JSON formatter does not remove ​​​​​​​​​​​​empty lines​​
-​​​
-### Updated​
+### Fixed
 
-- `jsonc-parser` library upgraded from ​v2 to v3
+- JSON formatter does not remove empty lines
+
+### Updated
+
+- `jsonc-parser` library upgraded from v2 to v3
 
 ## 1.3.19
 
 ### Fixed
 
-- `vm2` library security patch​
+- `vm2` library security patch
 
 ## 1.3.18
 
@@ -84,9 +84,9 @@
 
 ## 1.3.7
 
-### Updated​
-​
-- Using Update instead of Publish on Web Hooks​​
+### Updated
+
+- Using Update instead of Publish on Web Hooks
 - Fixed Top Level string RPC calls in JSONCs
 - Fixed Export Command
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
-# Change Log
+​# Change Log
+
+​## 1.3.20
+​​​​​​
+### Fixed​
+
+- JSON formatter does not remove ​​​​​​​​​​​​empty lines​​
+​​​
+### Updated​
+
+- `jsonc-parser` library upgraded from ​v2 to v3
 
 ## 1.3.19
 
 ### Fixed
 
-- `vm2` library security patch
+- `vm2` library security patch​
 
 ## 1.3.18
 
@@ -74,8 +84,8 @@
 
 ## 1.3.7
 
-### Updated
-
+### Updated​
+​
 - Using Update instead of Publish on Web Hooks​​
 - Fixed Top Level string RPC calls in JSONCs
 - Fixed Export Command

--- a/extension.js
+++ b/extension.js
@@ -186,7 +186,7 @@ async function activate(context) {
 		vscode.languages.registerDocumentFormattingEditProvider({ language: 'imljson', scheme: 'file' }, {
 			provideDocumentFormattingEdits(document) {
 				let text = document.getText()
-				let edits = jsoncParser.format(text, undefined, { insertSpaces: 4 })
+				let edits = jsoncParser.format(text, undefined, { insertSpaces: true, tabSize: 4, keepLines: true })
 				return edits.map(edit => {
 					let start = document.positionAt(edit.offset)
 					let end = document.positionAt(edit.offset + edit.length)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"compressing": "^1.5.1",
 				"image-downloader": "^3.6.0",
 				"jimp": "^0.10.3",
-				"jsonc-parser": "^2.3.0",
+				"jsonc-parser": "^3.2.0",
 				"lodash.camelcase": "^4.3.0",
 				"lodash.kebabcase": "^4.1.1",
 				"lodash.pick": "^4.4.0",
@@ -1230,9 +1230,9 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"node_modules/jsonc-parser": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.0.tgz",
-			"integrity": "sha512-b0EBt8SWFNnixVdvoR2ZtEGa9ZqLhbJnOjezn+WP+8kspFm+PFYDN8Z4Bc7pRlDjvuVcADSUkroIuTWWn/YiIA=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
 		},
 		"node_modules/jsprim": {
 			"version": "1.4.1",
@@ -2039,6 +2039,11 @@
 				"vscode-nls": "^4.1.2",
 				"vscode-uri": "^2.1.2"
 			}
+		},
+		"node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+			"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
 		},
 		"node_modules/vscode-json-languageservice/node_modules/vscode-uri": {
 			"version": "2.1.2",
@@ -3215,9 +3220,9 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"jsonc-parser": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.0.tgz",
-			"integrity": "sha512-b0EBt8SWFNnixVdvoR2ZtEGa9ZqLhbJnOjezn+WP+8kspFm+PFYDN8Z4Bc7pRlDjvuVcADSUkroIuTWWn/YiIA=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3921,6 +3926,11 @@
 				"vscode-uri": "^2.1.2"
 			},
 			"dependencies": {
+				"jsonc-parser": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+					"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
+				},
 				"vscode-uri": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "apps-sdk",
 	"displayName": "Make Apps SDK",
 	"description": "Make Apps SDK plugin for Visual Studio Code",
-	"version": "1.3.19",
+	"version": "1.3.20​",
 	"icon": "resources/make.png",
 	"repository": {
 		"type": "git",
@@ -759,7 +759,7 @@
 		"compressing": "^1.5.1",
 		"image-downloader": "^3.6.0",
 		"jimp": "^0.10.3",
-		"jsonc-parser": "^2.3.0",
+		"jsonc-parser": "^3.2.0",
 		"lodash.camelcase": "^4.3.0",
 		"lodash.kebabcase": "^4.1.1",
 		"lodash.pick": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "apps-sdk",
 	"displayName": "Make Apps SDK",
 	"description": "Make Apps SDK plugin for Visual Studio Code",
-	"version": "1.3.20​",
+	"version": "1.3.20",
 	"icon": "resources/make.png",
 	"repository": {
 		"type": "git",

--- a/src/Core.js
+++ b/src/Core.js
@@ -215,7 +215,7 @@ module.exports = {
 	},
 
 	formatJsonc: function (text) {
-		let edits = jsoncParser.format(text, undefined, { insertSpaces: 4 })
+		let edits = jsoncParser.format(text, undefined, { insertSpaces: true, tabSize: 4, keepLines: true })
 		let formatted = jsoncParser.applyEdits(text, edits)
 		return formatted
 	},

--- a/src/Meta.js
+++ b/src/Meta.js
@@ -1,3 +1,3 @@
 module.exports = {
-	version: '1.3.19'
+	version: '1.3.20'
 };


### PR DESCRIPTION
### Issue

JSONC formatter is removing all empty lines in documents.

### Root cause

Lib `node-jsonc-parser`, method `format()`. There was similar issue in VS Code, which has been already solved by adding option `keepLines` into this lib.

### Solution

Upgrade `node-jsonc-parser` and set `keepLines` flag.

### Testing

Updated extension tested on my local machine in VS Code. Works.

### Relates links

* https://github.com/microsoft/vscode/issues/23260
* https://github.com/microsoft/node-jsonc-parser/pull/66