### PR TITLE
fix: Uploading of files not belonging to extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Fixed
 
 - Module deletion
+- Attempts to upload files not belonging to extension
+
+# Changes
+
+- Temporary directory is removed on the end of extension lifecycle
 
 ## 1.3.20
 

--- a/src/commands/CoreCommands.js
+++ b/src/commands/CoreCommands.js
@@ -16,7 +16,7 @@ const path = require('path')
 const { mkdir, writeFile } = require('fs/promises');
 const axios = require('axios');
 const { showError } = require('../error-handling')
-const { sourceCodeLocalTempBasedir, isFileBelongsToExtension } = require('../temp-dir');
+const { isFileBelongingToExtension } = require('../temp-dir');
 const { log } = require('../output-channel')
 
 class CoreCommands {
@@ -44,7 +44,7 @@ class CoreCommands {
 	async sourceUpload(event /*: vscode.TextDocumentWillSaveEvent*/) {
 
 		// It it's not an APPS SDK file, don't do anything
-		if (!isFileBelongsToExtension(event.document.fileName)) {
+		if (!isFileBelongingToExtension(event.document.fileName)) {
 			if (/[/\\]apps-sdk[/\\]/.test(event.document.fileName)) {
 				vscode.window.showWarningMessage(
 					'File upload to Make has been cancelled. You are trying to save some old file from previous run ' +

--- a/src/commands/CoreCommands.js
+++ b/src/commands/CoreCommands.js
@@ -16,6 +16,8 @@ const path = require('path')
 const { mkdir, writeFile } = require('fs/promises');
 const axios = require('axios');
 const { showError } = require('../error-handling')
+const { sourceCodeLocalTempBasedir } = require('../temp-dir');
+const { log } = require('../output-channel')
 
 class CoreCommands {
 	constructor(appsProvider, _authorization, _environment, rpcProvider, imlProvider, parametersProvider, staticImlProvider, tempProvider, dataProvider, groupsProvider) {
@@ -34,13 +36,26 @@ class CoreCommands {
 		this.tempListener = null
 	}
 
-    /**
-     * Source Uploader
-     */
-	async sourceUpload(event) {
+	/**
+	 * Source Uploader
+	 * @param {vscode.TextDocumentWillSaveEvent} event
+	 * @returns {Promise<void>}
+	 */
+	async sourceUpload(event /*: vscode.TextDocumentWillSaveEvent*/) {
 
 		// It it's not an APPS SDK file, don't do anything
-		if (!event.document.fileName.includes('apps-sdk')) { return }
+		if (!event.document.fileName.includes(sourceCodeLocalTempBasedir)) {
+			if (/[/\\]apps-sdk[/\\]/.test(event.document.fileName)) {
+				vscode.window.showWarningMessage(
+					'File upload to Make has been cancelled. You are trying to save some old file from previous run ' +
+					'of the VS Code. File is not up-to-date, therefore Make Apps Extension ignores it now. ' +
+					'Please, reopen the file again from menu in Make Apps Extension, then you will be able to ' +
+					'edit and save it. ' +
+					`File: ${event.document.fileName}}`
+				);
+			} // Else // Everything is OK, user is saving some non SDK-App file, therefore ignore it silencely.
+			return;
+		}
 
 		// Load the content of the file that's about to be saved
 		let file = event.document.getText()
@@ -103,13 +118,15 @@ class CoreCommands {
 			options.headers["Content-Type"] = "application/json"
 		}
 
-        /**
-         * CODE-UPLOADER
-         * Those lines are directly responsible for the code being uploaded
-         */
+		/**
+		 * CODE-UPLOADER
+		 * Those lines are directly responsible for the code being uploaded
+		 */
 		try {
 			// Get the response from server
 			const axiosResponse = await axios(options);
+
+			log('info', `File ${right} saved/uploaded successfully`);
 
 			// If there's no change to be displayed, end
 			if (!axiosResponse.data.change || Object.keys(axiosResponse.data.change).length === 0) { return; }
@@ -118,7 +135,7 @@ class CoreCommands {
 			this.appsProvider.refresh()
 		}
 		catch (err) {
-			showError(err, 'File saving/uploading failed');
+			showError(err, `File ${event?.document?.fileName} saving/uploading failed`);
 
 			// Mark the document as dirty (Adds a space and remove it)
 			const editor = vscode.window.activeTextEditor
@@ -132,9 +149,9 @@ class CoreCommands {
 		}
 	}
 
-    /**
-     * Provider Keeper
-     */
+	/**
+	 * Provider Keeper
+	 */
 	async keepProviders(editor) {
 		{
 
@@ -169,11 +186,11 @@ class CoreCommands {
 			/**
 			 *   ###              #    #       ####### ######  #######
 			 *   ###             # #   #       #       #     #    #
-             *   ###            #   #  #       #       #     #    #
-             *    #            #     # #       #####   ######     #
-             *                 ####### #       #       #   #      #
-             *   ###           #     # #       #       #    #     #
-             *   ###           #     # ####### ####### #     #    #
+			 *   ###            #   #  #       #       #     #    #
+			 *    #            #     # #       #####   ######     #
+			 *                 ####### #       #       #   #      #
+			 *   ###           #     # #       #       #    #     #
+			 *   ###           #     # ####### ####### #     #    #
 			 *
 			 * The version is fixed here, because we didn't know how to make it nonfixed at the time
 			 * This should be changed when the connection is separated from the app
@@ -241,11 +258,11 @@ class CoreCommands {
 				name = crumbs[5].split(".")[0]
 			}
 
-            /**
-             * RPC-LOADER
-             * RpcLoader loads all RPCs available within the app
-             * Following condition specifies where are RPCs allowed
-             */
+			/**
+			 * RPC-LOADER
+			 * RpcLoader loads all RPCs available within the app
+			 * Following condition specifies where are RPCs allowed
+			 */
 			if (
 				((apiPath === "connections" || apiPath === "connection") && name === "parameters") ||
 				((apiPath === "webhook" || apiPath === "webhooks") && name === "parameters") ||
@@ -281,11 +298,11 @@ class CoreCommands {
 				}
 			}
 
-            /**
-             * IML-LOADER
-             * ImlLoader loads all IML functions available within the app
-             * Following condition specifies where are IML functions allowed
-             */
+			/**
+			 * IML-LOADER
+			 * ImlLoader loads all IML functions available within the app
+			 * Following condition specifies where are IML functions allowed
+			 */
 			if (
 				(name === "base" || name === "api" || name === "api-oauth" || name === "epoch" || name === "attach" || name === "detach" || name === "update")
 			) {
@@ -318,11 +335,11 @@ class CoreCommands {
 				}
 			}
 
-            /**
-             * PARAMETERS-LOADER
-             * VariablesLoader will load all context-related and available IML variables
-             * Following condition specifies where and how should be the variables provided
-             */
+			/**
+			 * PARAMETERS-LOADER
+			 * VariablesLoader will load all context-related and available IML variables
+			 * Following condition specifies where and how should be the variables provided
+			 */
 
 			if (
 				apiPath !== 'base' && (name === "api" || name === "api-oauth" || name === "epoch" || name === "attach" || name === "detach" || name === "update")
@@ -349,10 +366,10 @@ class CoreCommands {
 				}
 			}
 
-            /**
-             * STATIC-IML-LOADER
-             * Static IML loader provides inbuilt IML functions and keywords.
-             */
+			/**
+			 * STATIC-IML-LOADER
+			 * Static IML loader provides inbuilt IML functions and keywords.
+			 */
 
 			if (this.sipInit === false) {
 				await this.staticImlProvider.initialize()
@@ -516,9 +533,9 @@ class CoreCommands {
 
 	static async register(_DIR, _authorization, _environment) {
 
-        /**
-         * OpenSource Loader
-         */
+		/**
+		 * OpenSource Loader
+		 */
 		vscode.commands.registerCommand('apps-sdk.load-open-source', async function (item) {
 
 			// Compose directory structure
@@ -566,10 +583,10 @@ class CoreCommands {
 			let filepath = `${urnForFile}.${item.language}`
 			let dirname = path.dirname(filepath)
 
-            /**
-             * CODE-LOADER
-             * Code loader loads the requested code
-             */
+			/**
+			 * CODE-LOADER
+			 * Code loader loads the requested code
+			 */
 
 			// Prepare the directory for the code
 			try {
@@ -578,10 +595,10 @@ class CoreCommands {
 				// Compose a download URL
 				let url = _environment.baseUrl + urn
 
-                /**
-                 * GET THE SOURCE CODE
-                 * Those lines are responsible straight for the download of code
-                 */
+				/**
+				 * GET THE SOURCE CODE
+				 * Those lines are responsible straight for the download of code
+				 */
 				const axiosResponse = await axios({
 					url: url,
 					headers: {
@@ -608,9 +625,9 @@ class CoreCommands {
 			}
 		})
 
-        /**
-         * Source Loader
-         */
+		/**
+		 * Source Loader
+		 */
 		vscode.commands.registerCommand('apps-sdk.load-source', async function (item) {
 
 			// Compose directory structure
@@ -666,10 +683,10 @@ class CoreCommands {
 				filepath = `${urnForFile}-oauth.${item.language}`
 			}
 
-            /**
-             * CODE-LOADER
-             * Code loader loads the requested code
-             */
+			/**
+			 * CODE-LOADER
+			 * Code loader loads the requested code
+			 */
 
 			try {
 				// Prepare the directory for the code
@@ -679,10 +696,10 @@ class CoreCommands {
 				// Compose a download URL
 				let url = _environment.baseUrl + urn
 
-                /**
-                 * GET THE SOURCE CODE
-                 * Those lines are responsible straight for the download of code
-                 */
+				/**
+				 * GET THE SOURCE CODE
+				 * Those lines are responsible straight for the download of code
+				 */
 				const axiosResponse = await axios({
 					url: url,
 					headers: {

--- a/src/commands/CoreCommands.js
+++ b/src/commands/CoreCommands.js
@@ -16,7 +16,7 @@ const path = require('path')
 const { mkdir, writeFile } = require('fs/promises');
 const axios = require('axios');
 const { showError } = require('../error-handling')
-const { sourceCodeLocalTempBasedir } = require('../temp-dir');
+const { sourceCodeLocalTempBasedir, isFileBelongsToExtension } = require('../temp-dir');
 const { log } = require('../output-channel')
 
 class CoreCommands {
@@ -44,7 +44,7 @@ class CoreCommands {
 	async sourceUpload(event /*: vscode.TextDocumentWillSaveEvent*/) {
 
 		// It it's not an APPS SDK file, don't do anything
-		if (!event.document.fileName.includes(sourceCodeLocalTempBasedir)) {
+		if (!isFileBelongsToExtension(event.document.fileName)) {
 			if (/[/\\]apps-sdk[/\\]/.test(event.document.fileName)) {
 				vscode.window.showWarningMessage(
 					'File upload to Make has been cancelled. You are trying to save some old file from previous run ' +

--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -18,6 +18,10 @@ export function showError(err: Error | AxiosError<any> | string, title: string|u
 		e = `[${e.name}] ${e.message}`;
 	}
 
+	if (e instanceof Object || e instanceof Array) {
+		e = JSON.stringify(e);
+	}
+
 	e = (title ? title + ': ' : '') + String(e);
 
 	// Show error message in VS Code

--- a/src/temp-dir.ts
+++ b/src/temp-dir.ts
@@ -1,0 +1,24 @@
+import { join } from "path";
+import * as tempy from "tempy";
+import * as fs from "fs";
+import { log } from "./output-channel";
+
+/**
+ * The path to the local temporary directory where the source code of the SDK is placed during editation.
+ *
+ * Note: Path is unique for each run of the extension.
+ */
+export const sourceCodeLocalTempBasedir = join(tempy.directory(), "apps-sdk");
+
+/**
+ * Remove the local temporary directory from disk.
+ */
+export function rmCodeLocalTempBasedir() {
+	if (!sourceCodeLocalTempBasedir.includes("apps-sdk")) {
+		// Make sure, that the subdir is defined correctly (to prevent accidental deletion of another data on disk)
+		throw new Error('Unexpected sourceCodeLocalTempBasedir value: ' + sourceCodeLocalTempBasedir);
+	}
+	log('info', 'Cleaning up the source code local temp basedir: ' + sourceCodeLocalTempBasedir);
+	// Delete dir "dir" recurisively
+	fs.rmSync(sourceCodeLocalTempBasedir, {recursive: true});
+}

--- a/src/temp-dir.ts
+++ b/src/temp-dir.ts
@@ -2,6 +2,8 @@ import { join } from "path";
 import * as tempy from "tempy";
 import * as fs from "fs";
 import { log } from "./output-channel";
+import * as vscode from "vscode";
+
 
 /**
  * The path to the local temporary directory where the source code of the SDK is placed during editation.
@@ -9,6 +11,16 @@ import { log } from "./output-channel";
  * Note: Path is unique for each run of the extension.
  */
 export const sourceCodeLocalTempBasedir = join(tempy.directory(), "apps-sdk");
+
+
+/**
+ * Checks if the given file name belongs to the local temporary directory
+ * where the source code of this extension is placed during editation.
+ */
+export function isFileBelongsToExtension(fileName: string): boolean {
+	return fileName.includes(sourceCodeLocalTempBasedir);
+}
+
 
 /**
  * Remove the local temporary directory from disk.
@@ -18,7 +30,13 @@ export function rmCodeLocalTempBasedir() {
 		// Make sure, that the subdir is defined correctly (to prevent accidental deletion of another data on disk)
 		throw new Error('Unexpected sourceCodeLocalTempBasedir value: ' + sourceCodeLocalTempBasedir);
 	}
-	log('info', 'Cleaning up the source code local temp basedir: ' + sourceCodeLocalTempBasedir);
-	// Delete dir "dir" recurisively
-	fs.rmSync(sourceCodeLocalTempBasedir, {recursive: true});
+
+	// Clean up the source code local temp basedir if nothing kept open
+	const someAppFileKeptOpen = vscode.workspace.textDocuments.some((textDocuments) => (
+		isFileBelongsToExtension(textDocuments.fileName)
+	));
+	if (!someAppFileKeptOpen) {
+		log('info', 'Cleaning up the source code local temp basedir: ' + sourceCodeLocalTempBasedir);
+		fs.rmSync(sourceCodeLocalTempBasedir, {recursive: true});
+	}
 }

--- a/src/temp-dir.ts
+++ b/src/temp-dir.ts
@@ -17,7 +17,7 @@ export const sourceCodeLocalTempBasedir = join(tempy.directory(), "apps-sdk");
  * Checks if the given file name belongs to the local temporary directory
  * where the source code of this extension is placed during editation.
  */
-export function isFileBelongsToExtension(fileName: string): boolean {
+export function isFileBelongingToExtension(fileName: string): boolean {
 	return fileName.includes(sourceCodeLocalTempBasedir);
 }
 
@@ -33,7 +33,7 @@ export function rmCodeLocalTempBasedir() {
 
 	// Clean up the source code local temp basedir if nothing kept open
 	const someAppFileKeptOpen = vscode.workspace.textDocuments.some((textDocuments) => (
-		isFileBelongsToExtension(textDocuments.fileName)
+		isFileBelongingToExtension(textDocuments.fileName)
 	));
 	if (!someAppFileKeptOpen) {
 		log('info', 'Cleaning up the source code local temp basedir: ' + sourceCodeLocalTempBasedir);


### PR DESCRIPTION
Original algoritm made decision if saving file belongs to Make Extension based on if directory path includes "sdk-app" string. But it causes 2 issues:
 - Extension uploaded to Make also files, which kept opened in VS Code from previous running.
 - Extension tried to upload absolutely every file which has the `sdk-app` in path, even if the file was absolutely irelevant to extension. In this case it generated failing message on each save in VS Code.
 
 Issue 3: Extension kept all temp files on local drive and it neved made cleanup.
 Fix: Extension is now deletion own temp dir on each deactivation.