### PR TITLE
fix: activation fail on first run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ Change Log
 
 ### Fixed
 
-- Error during app import (issue #21)
+- Error during app import (#21)
 - Fail to save file kept open during VS Code restart
+- Fail to activate the extension for new users with no settings (#87)
 
 ### Changes
 
 - Keep original indent of JSON files. Do not execute the auto format automatically.
 - Update dependencies `request-light`, `uuid`, `vscode-json-languageservice`, `vscode-languageclient`, `vscode-languageserver`, `tempy`
+- First environment configuration process is more friendly (#87)
 
 1.3.22
 ------

--- a/src/commands/EnvironmentCommands.js
+++ b/src/commands/EnvironmentCommands.js
@@ -60,6 +60,7 @@ class EnvironmentCommands {
 			// Check if filled
 			if (!Core.isFilled("API key", "your account", apikey, "An", false)) { return }
 
+			// Check the new token validity
 			if (version.description === '2') {
 				let uri = `https://${url}/v2/users/me`
 				try {
@@ -71,8 +72,13 @@ class EnvironmentCommands {
 						}
 					})
 				} catch (err) {
-					vscode.window.showWarningMessage(err.error ? err.error.message : err)
-					vscode.window.showInformationMessage('Environment probe failed. You can try to set the environment in VSCode settings.json manually.');
+					const input = await vscode.window.showWarningMessage(
+						"Your token was probably not valid or some error ocured. Please try again to start using Make Apps SDK.",
+						"Add environment"
+					);
+					if (input === "Add environment") {
+						vscode.commands.executeCommand('apps-sdk.env.add');
+					}
 					return;
 				}
 			} else {


### PR DESCRIPTION
Issue
-----

Extension activation fails if user is activating it on his computer for first time (without extension config stored in VS Code setting.json) + user will cancel the dialog with offer to add new environment. Offer dialog is currently the part of activation function, so it causes failing whole activation process.

Fix
----
- Dialog is executed AFTER the activation - independently on activation function.

Improvement
-------------

- User friendly message if token is invalid.
- User is asked to try again if token is invalid and see the button "Add environment" to be able to simple retry.