### PR TITLE
Bug: Custom function testing fails, when using another custom function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Change Log
 
 ### Fixed
 
-- Fail a custom function testing, when using another custom function (#105)
+- Custom function testing fails, when using another custom function (#105)
 
 1.3.27
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+1.3.28 (pre-release)
+--------------------
+
+### Fixed
+
+- Fail a custom function testing, when using another custom function (#105)
+
 1.3.27
 ------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "apps-sdk",
-	"version": "1.3.27",
+	"version": "1.3.28",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "apps-sdk",
-			"version": "1.3.27",
+			"version": "1.3.28",
 			"dependencies": {
 				"@integromat/iml": "^2.19.11",
 				"@integromat/udt": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "apps-sdk",
 			"version": "1.3.27",
 			"dependencies": {
-				"@integromat/iml": "^1.22.5",
+				"@integromat/iml": "^2.19.11",
 				"@integromat/udt": "^1.2.0",
 				"adm-zip": "^0.5.10",
 				"async-file": "^2.0.2",
@@ -168,17 +168,22 @@
 			}
 		},
 		"node_modules/@integromat/iml": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@integromat/iml/-/iml-1.27.0.tgz",
-			"integrity": "sha512-IQkG0OEUFcjGHUpFbhQZPUO61FFATzLHmDl97QBXKz16D42+Vk8ETTPjmOcMzbf2YsjpYDwNgK/89b5BZq7+yQ==",
+			"version": "2.19.11",
+			"resolved": "https://registry.npmjs.org/@integromat/iml/-/iml-2.19.11.tgz",
+			"integrity": "sha512-zd6ESZ1PncZWdS65PpRqQzrjxf09WF7SPDLqBqKktNBGQhp6//dwwpQnEHyTK5ewQtRyrFu54SCehUMEsfEN3g==",
+			"hasInstallScript": true,
 			"dependencies": {
-				"@integromat/dateparser": "^1.3.5",
+				"@integromat/dateparser": "^1.3.6",
 				"decimal.js": "^10.2.0",
-				"moment-timezone": "^0.5.26",
-				"semver": "^7.3.5"
+				"isolated-vm": "^4.6.0",
+				"moment-timezone": "^0.5.31",
+				"nan": "^2.17.0",
+				"node-addon-api": "^5.0.0",
+				"semver": "^7.3.5",
+				"utf8": "3.0.0"
 			},
 			"engines": {
-				"node": ">=6.0"
+				"node": ">=16.0"
 			}
 		},
 		"node_modules/@integromat/udt": {
@@ -1312,6 +1317,11 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -1482,6 +1492,28 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1548,6 +1580,14 @@
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/diff": {
@@ -1797,6 +1837,14 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
 			"integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -2076,6 +2124,11 @@
 				"omggif": "^1.0.10"
 			}
 		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+		},
 		"node_modules/glob": {
 			"version": "10.3.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
@@ -2348,6 +2401,11 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2459,6 +2517,18 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/isolated-vm": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.6.0.tgz",
+			"integrity": "sha512-MEnfC/54q5PED3VJ9UJYJPOlU6mYFHS3ivR9E8yeNNBEFRFUNBnY0xO4Rj3D/SOtFKPNmsQp9NWUYSKZqAoZiA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"prebuild-install": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
 		},
 		"node_modules/isomorphic-fetch": {
 			"version": "3.0.0",
@@ -2697,6 +2767,17 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/min-document": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -2743,6 +2824,11 @@
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
 		"node_modules/mocha": {
 			"version": "10.2.0",
@@ -2883,6 +2969,11 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"node_modules/nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
@@ -2895,11 +2986,32 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/napi-build-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/node-abi": {
+			"version": "3.47.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
+			"integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+			"integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.13",
@@ -3154,6 +3266,31 @@
 				"node": ">=12.13.0"
 			}
 		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3225,6 +3362,28 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -3458,6 +3617,49 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3612,6 +3814,55 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-fs/node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/tar-fs/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/tar-fs/node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/tar-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
@@ -3731,6 +3982,17 @@
 				"typescript": ">=4.2.0"
 			}
 		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3787,6 +4049,11 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"node_modules/utf8": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
 		},
 		"node_modules/utif2": {
 			"version": "4.1.0",
@@ -4278,14 +4545,18 @@
 			}
 		},
 		"@integromat/iml": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@integromat/iml/-/iml-1.27.0.tgz",
-			"integrity": "sha512-IQkG0OEUFcjGHUpFbhQZPUO61FFATzLHmDl97QBXKz16D42+Vk8ETTPjmOcMzbf2YsjpYDwNgK/89b5BZq7+yQ==",
+			"version": "2.19.11",
+			"resolved": "https://registry.npmjs.org/@integromat/iml/-/iml-2.19.11.tgz",
+			"integrity": "sha512-zd6ESZ1PncZWdS65PpRqQzrjxf09WF7SPDLqBqKktNBGQhp6//dwwpQnEHyTK5ewQtRyrFu54SCehUMEsfEN3g==",
 			"requires": {
-				"@integromat/dateparser": "^1.3.5",
+				"@integromat/dateparser": "^1.3.6",
 				"decimal.js": "^10.2.0",
-				"moment-timezone": "^0.5.26",
-				"semver": "^7.3.5"
+				"isolated-vm": "^4.6.0",
+				"moment-timezone": "^0.5.31",
+				"nan": "^2.17.0",
+				"node-addon-api": "^5.0.0",
+				"semver": "^7.3.5",
+				"utf8": "3.0.0"
 			}
 		},
 		"@integromat/udt": {
@@ -5087,6 +5358,11 @@
 				}
 			}
 		},
+		"chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+		},
 		"clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -5218,6 +5494,19 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
 		},
+		"decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"requires": {
+				"mimic-response": "^3.1.0"
+			}
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+		},
 		"deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5266,6 +5555,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+		},
+		"detect-libc": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
 		},
 		"diff": {
 			"version": "5.0.0",
@@ -5447,6 +5741,11 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
 			"integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+		},
+		"expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -5655,6 +5954,11 @@
 				"omggif": "^1.0.10"
 			}
 		},
+		"github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+		},
 		"glob": {
 			"version": "10.3.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
@@ -5854,6 +6158,11 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5929,6 +6238,14 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"isolated-vm": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.6.0.tgz",
+			"integrity": "sha512-MEnfC/54q5PED3VJ9UJYJPOlU6mYFHS3ivR9E8yeNNBEFRFUNBnY0xO4Rj3D/SOtFKPNmsQp9NWUYSKZqAoZiA==",
+			"requires": {
+				"prebuild-install": "^7.1.1"
+			}
 		},
 		"isomorphic-fetch": {
 			"version": "3.0.0",
@@ -6120,6 +6437,11 @@
 				"mime-db": "1.52.0"
 			}
 		},
+		"mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+		},
 		"min-document": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -6154,6 +6476,11 @@
 			"requires": {
 				"minimist": "^1.2.6"
 			}
+		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
 		"mocha": {
 			"version": "10.2.0",
@@ -6265,17 +6592,40 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+		},
 		"nanoid": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
 			"integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
 			"dev": true
 		},
+		"napi-build-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node-abi": {
+			"version": "3.47.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
+			"integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+			"requires": {
+				"semver": "^7.3.5"
+			}
+		},
+		"node-addon-api": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+			"integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
 		},
 		"node-fetch": {
 			"version": "2.6.13",
@@ -6454,6 +6804,25 @@
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
 			"integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
 		},
+		"prebuild-install": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"requires": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			}
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6502,6 +6871,24 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
+			}
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+				}
 			}
 		},
 		"readable-stream": {
@@ -6674,6 +7061,21 @@
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true
 		},
+		"simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+		},
+		"simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"requires": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6781,6 +7183,51 @@
 				"has-flag": "^4.0.0"
 			}
 		},
+		"tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+					"requires": {
+						"buffer": "^5.5.0",
+						"inherits": "^2.0.4",
+						"readable-stream": "^3.4.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"tar-stream": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+					"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+					"requires": {
+						"bl": "^4.0.3",
+						"end-of-stream": "^1.4.1",
+						"fs-constants": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.1.1"
+					}
+				}
+			}
+		},
 		"tar-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
@@ -6869,6 +7316,14 @@
 			"dev": true,
 			"requires": {}
 		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6906,6 +7361,11 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"utf8": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
 		},
 		"utif2": {
 			"version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -765,7 +765,7 @@
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
-		"@integromat/iml": "^1.22.5",
+		"@integromat/iml": "^2.19.11",
 		"@integromat/udt": "^1.2.0",
 		"adm-zip": "^0.5.10",
 		"async-file": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "apps-sdk",
 	"displayName": "Make Apps SDK",
 	"description": "Make Apps SDK plugin for Visual Studio Code",
-	"version": "1.3.27",
+	"version": "1.3.28",
 	"icon": "resources/make.png",
 	"repository": {
 		"type": "git",

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -7,7 +7,7 @@ import * as Meta from './Meta';
 import { showError } from './error-handling';
 
 
-export async function rpGet(uri: string, authorization: string, qs?: Record<string, string>) {
+export async function rpGet(uri: string, authorization: string, qs?: Record<string, string|string[]|boolean>) {
 	try {
 		return (await axios({
 			url: uri,
@@ -47,7 +47,7 @@ export function envGuard(environment: Environment, available: number[]) {
 	return true;
 }
 
-export function isFilled(subject: string, object: string, thing: any, article: string, the: boolean) {
+export function isFilled(subject: string, object: string, thing: any, article?: string, the?: boolean) {
 	if (thing === undefined || thing === "" || thing === null) {
 		vscode.window.showWarningMessage(`${article || "A"} ${subject} for ${the === false ? "" : "the"} ${object} has not been specified.`);
 		return false;

--- a/src/commands/FunctionCommands.ts
+++ b/src/commands/FunctionCommands.ts
@@ -4,7 +4,7 @@ import * as Core from '../Core';
 import * as Validator from '../Validator';
 
 import { VM, VMOptions, VMScript } from 'vm2';
-const { IML } = require('@integromat/iml');
+import { IML } from '@integromat/iml';
 import { catchError } from '../error-handling';
 import { Environment } from '../types/environment.types';
 import AppsProvider from '../providers/AppsProvider';

--- a/src/commands/FunctionCommands.ts
+++ b/src/commands/FunctionCommands.ts
@@ -103,7 +103,7 @@ export class FunctionCommands {
 			const test = await Core.rpGet(`${urn}/${functionName}/test`, _authorization)
 
 			// Get users' functions
-			let userFunctions: any[] = await Core.rpGet(`${urn}?cols[]=code`, _authorization, { code: true })
+			let userFunctions: { name: string, code: string }[] = await Core.rpGet(`${urn}`, _authorization, { code: true, cols: ['name', 'code'] })
 			if (_environment.version === 2) {
 				userFunctions = (<any>userFunctions).appFunctions;
 			}

--- a/src/commands/FunctionCommands.ts
+++ b/src/commands/FunctionCommands.ts
@@ -1,47 +1,50 @@
-/* eslint-disable semi,@typescript-eslint/no-var-requires */
-const vscode = require('vscode')
+import * as vscode from 'vscode';
 
-const Core = require('../Core')
-const Validator = require('../Validator')
+import * as Core from '../Core';
+import * as Validator from '../Validator';
 
-const { VM, VMScript } = require('vm2')
-const { IML } = require('@integromat/iml')
-const { showError, catchError } = require('../error-handling');
+import { VM, VMOptions, VMScript } from 'vm2';
+const { IML } = require('@integromat/iml');
+import { catchError } from '../error-handling';
+import { Environment } from '../types/environment.types';
+import AppsProvider from '../providers/AppsProvider';
 
-class FunctionCommands {
-	static async register(appsProvider, _authorization, _environment, _timezone) {
+export class FunctionCommands {
+	static async register(
+		appsProvider: AppsProvider, _authorization: string, _environment: Environment, _timezone: string
+	) {
 
-		var outputChannel = vscode.window.createOutputChannel("IML tests")
+		const outputChannel = vscode.window.createOutputChannel('IML tests')
 
-        /**
-         * New function
-         */
+		/**
+		 * New function
+		 */
 		vscode.commands.registerCommand('apps-sdk.function.new', catchError('Function creation', async (context) => {
 
 			// If called out of context -> die
 			if (!Core.contextGuard(context)) { return }
 
 			// Get the source app
-			let app = context.parent
+			const app = context.parent
 
 			// Prompt for the function name
-			let name = await vscode.window.showInputBox({
-				prompt: "Enter function name",
+			const name = await vscode.window.showInputBox({
+				prompt: 'Enter function name',
 				ignoreFocusOut: false,
 				validateInput: Validator.functionName
 			})
 
 			// If not filled -> die
-			if (!Core.isFilled("name", "function", name)) { return }
+			if (!Core.isFilled('name', 'function', name)) { return }
 
 			// Add the new entity. Refresh the tree or show the error
-			await Core.addEntity(_authorization, { "name": name }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, 'function')}`)
+			await Core.addEntity(_authorization, { name: name }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, 'function')}`)
 			appsProvider.refresh()
 		}));
 
-        /**
-         * Run function test
-         */
+		/**
+		 * Run function test
+		 */
 		vscode.commands.registerCommand('apps-sdk.function.test', async function (context) {
 
 			let urn
@@ -49,10 +52,9 @@ class FunctionCommands {
 
 			// If called out of context -> gather the required information
 			if (context === undefined || context === null) {
-				let crumbs
 				// If a window is open
 				if (!vscode.window.activeTextEditor) {
-					vscode.window.showErrorMessage("Active text editor not found.")
+					vscode.window.showErrorMessage('Active text editor not found.')
 					return
 				}
 				// If an apps file is open
@@ -61,10 +63,10 @@ class FunctionCommands {
 					return
 				}
 				// Parse the path
-				crumbs = vscode.window.activeTextEditor.document.uri.fsPath.split('apps-sdk')[1].split('/').reverse()
+				const crumbs = vscode.window.activeTextEditor.document.uri.fsPath.split('apps-sdk')[1].split('/').reverse()
 				// If crumbs were parsed
 				if (!crumbs) {
-					vscode.window.showErrorMessage("The path was not parsed successfully.")
+					vscode.window.showErrorMessage('The path was not parsed successfully.')
 					return
 				}
 				// If the path hasn't 8 or 7 crumbs it's definitely not a function
@@ -73,7 +75,7 @@ class FunctionCommands {
 					return
 				}
 				// If the path doesn't contain required crumbs
-				if (!((crumbs[0] === "test.js" || crumbs[0] === "code.js") && (crumbs[2] === "function" || crumbs[2] === "functions") && (crumbs[5] === "app" || crumbs[5] === "apps"))) {
+				if (!((crumbs[0] === 'test.js' || crumbs[0] === 'code.js') && (crumbs[2] === 'function' || crumbs[2] === 'functions') && (crumbs[5] === 'app' || crumbs[5] === 'apps'))) {
 					vscode.window.showErrorMessage("The parsed path doesn't correspond to the function test schema.")
 					return
 				}
@@ -86,47 +88,47 @@ class FunctionCommands {
 			else {
 				// Set correct URN (if called from function or core or test)
 				urn = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.getApp(context).name}/${Core.getApp(context).version}/${Core.pathDeterminer(_environment.version, 'function')}`
-				if (context.supertype === "function") {
+				if (context.supertype === 'function') {
 					functionName = `${context.name}`
 				}
-				else if (context.name === "code" || context.name === "test") {
+				else if (context.name === 'code' || context.name === 'test') {
 					functionName = `${context.parent.name}`
 				}
 			}
 
 			// Get current function code
-			let code = await Core.rpGet(`${urn}/${functionName}/code`, _authorization)
+			const code = await Core.rpGet(`${urn}/${functionName}/code`, _authorization)
 
 			// Get current test code
-			let test = await Core.rpGet(`${urn}/${functionName}/test`, _authorization)
+			const test = await Core.rpGet(`${urn}/${functionName}/test`, _authorization)
 
 			// Get users' functions
-			let userFunctions = await Core.rpGet(`${urn}?cols[]=code`, _authorization, { code: true })
+			let userFunctions: any[] = await Core.rpGet(`${urn}?cols[]=code`, _authorization, { code: true })
 			if (_environment.version === 2) {
-				userFunctions = userFunctions.appFunctions;
+				userFunctions = (<any>userFunctions).appFunctions;
 			}
 
 			// Merge codes
-			let codeToRun = `${code}\r\n\r\n/* === TEST CODE === */\r\n\r\n${test}`
+			const codeToRun = `${code}\r\n\r\n/* === TEST CODE === */\r\n\r\n${test}`
 
-            /**
-             *  Sandbox cookbook
-             *  - Assert for assertions
-             *  - IML for internal IML functions
-             *  - Users' IML functions
-             */
+			/**
+			 *  Sandbox cookbook
+			 *  - Assert for assertions
+			 *  - IML for internal IML functions
+			 *  - Users' IML functions
+			 */
 			let success = 0
 			let fail = 0
 			let total = 0
-			let sandbox = {
+			const sandbox: VMOptions['sandbox'] = {
 				assert: require('assert'),
 				iml: {},
-				it: (name, test) => {
+				it: (name: string, test: () => void) => {
 					total++
 					outputChannel.append(`- ${name} ... `)
 					try {
 						test()
-						outputChannel.appendLine(`✔`)
+						outputChannel.appendLine('✔')
 						success++
 					}
 					catch (err) {
@@ -150,14 +152,14 @@ class FunctionCommands {
 			const vm = new VM({
 				timeout: 5000,
 				sandbox: sandbox
-			})
+			});
 
-			vm.prepare = vm.run('(function(args) { global.__arguments__ = args })');
+			(vm as any).prepare = vm.run('(function(args) { global.__arguments__ = args })');
 
 			userFunctions.forEach(func => {
 				const preCompiled = new VMScript(`(${func.code}).apply({timezone: environment.timezone}, __arguments__)`, func.name);
-				sandbox.iml[func.name] = (...args) => {
-					vm.prepare(args);
+				sandbox.iml[func.name] = (...args: any[]) => {
+					(vm as any).prepare(args);
 					return vm.run(preCompiled);
 				};
 			});
@@ -166,23 +168,21 @@ class FunctionCommands {
 			outputChannel.show()
 			try {
 				vm.run(codeToRun)
-				outputChannel.appendLine(`----------- COMPLETED -----------`)
+				outputChannel.appendLine('----------- COMPLETED -----------')
 				outputChannel.appendLine(`Total test blocks: ${total}`)
 				outputChannel.appendLine(`Passed blocks: ${success}`)
 				outputChannel.appendLine(`Failed blocks: ${fail}`)
 				if (fail === 0) {
-					outputChannel.appendLine(`========== TEST PASSED ==========`)
+					outputChannel.appendLine('========== TEST PASSED ==========')
 				}
 				else {
-					outputChannel.appendLine(`========== TEST FAILED ==========`)
+					outputChannel.appendLine('========== TEST FAILED ==========')
 				}
 			}
-			catch (err) {
-				outputChannel.appendLine(`========= CRITICAL FAIL =========`)
+			catch (err: any) {
+				outputChannel.appendLine('========= CRITICAL FAIL =========')
 				outputChannel.appendLine(err)
 			}
 		})
 	}
 }
-
-module.exports = FunctionCommands

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import OpensourceProvider = require('./providers/OpensourceProvider');
 import ImljsonHoverProvider = require('./providers/ImljsonHoverProvider');
 
 import RpcCommands = require('./commands/RpcCommands');
-import FunctionCommands = require('./commands/FunctionCommands');
+import { FunctionCommands } from './commands/FunctionCommands';
 import ModuleCommands = require('./commands/ModuleCommands');
 import WebhookCommands = require('./commands/WebhookCommands');
 import ConnectionCommands = require('./commands/ConnectionCommands');
@@ -183,7 +183,18 @@ export async function activate(context: vscode.ExtensionContext) {
 	/**
 	 * Registering commands
 	 */
-	const coreCommands = new CoreCommands(appsProvider, _authorization, _environment, currentRpcProvider, currentImlProvider, currentParametersProvider, currentStaticImlProvider, currentTempProvider, currentDataProvider, currentGroupsProvider);
+	const coreCommands = new CoreCommands(
+		appsProvider,
+		_authorization,
+		_environment,
+		currentRpcProvider,
+		currentImlProvider,
+		currentParametersProvider,
+		currentStaticImlProvider,
+		currentTempProvider,
+		currentDataProvider,
+		currentGroupsProvider
+	);
 	await CoreCommands.register(sourceCodeLocalTempBasedir, _authorization, _environment);
 	await AppCommands.register(appsProvider, _authorization, _environment, _admin);
 	await ConnectionCommands.register(appsProvider, _authorization, _environment);
@@ -224,7 +235,7 @@ export async function deactivate() {
 	// Delete local temp dir
 	rmCodeLocalTempBasedir();
 
-	//Stop the language server client
+	// Stop the language server client
 	if (!client) {
 		return undefined;
 	}


### PR DESCRIPTION
Received bug report
===============

There is a longstanding bug within the VSCode extension that prevents the testing of functions utilising other functions written by user   When custom function is using another custom function then test is failing with error

 TypeError: iml.<function_name> is not a function . I have quickly investigated the issue and the bug can be easily fixed.What needs to be done:

src -> commands -> FunctionCommands.js

line 104

replace `?cols[]=code` with `?cols[]=name&cols[]=code`

The issue is that it is expected that function object has code and name  properties, in the current implementation the api call returns only code and that leads to the situation when custom functions are not added to the test context. It is a blocker for the Integration Engineering team to start with covering custom functions with tests and as it is very easy fix I would like to ask you to release it as soon as possible