### PR TITLE
fix: correct namespace of custom function in function body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unreleased
 - Migrate `vm2` to `node:vm`
 - Update (iml)json language server to 8.2.0-next.3
 
+### Fixed
+
+- Custom IML function was not correctly available under the namespace `iml.` in another function's body.
+
 1.3.28 (pre-release)
 --------------------
 

--- a/src/commands/FunctionCommands.test.ts
+++ b/src/commands/FunctionCommands.test.ts
@@ -109,7 +109,7 @@ suite('IML Functions Unit testing feature', () => {
 			{ name: 'getFive', code: 'function getFive() { return 5; }' },
 			{ name: 'getSix', code: 'function getSix() { return 6; }' },
 		];
-		const fakeFunc3Code = 'function fakeFunc3() { return getFive() + getSix(); }';
+		const fakeFunc3Code = 'function fakeFunc3() { return iml.getFive() + iml.getSix(); }';
 
 		test('Sucessful unit test', async () => {
 			const fakeFunc3SucessfullTestCode = `it('simulatedTestAccessAnotherCustomFunc', () => {

--- a/src/commands/FunctionCommands.ts
+++ b/src/commands/FunctionCommands.ts
@@ -182,7 +182,9 @@ export async function executeCustomFunctionTest(
 	const userFunctionsCode = userFunctions
 		.map((userFunction) => {
 			if (userFunction.name !== functionName) {
-				return `function ${userFunction.name} (...arguments) { return (${userFunction.code}).apply({timezone: environment.timezone}, arguments); }`;
+				return `iml['${userFunction.name}'] = function (...arguments) {` +
+					`    return (${userFunction.code}).apply({timezone: environment.timezone}, arguments); ` +
+					'};';
 			}
 		})
 		.join('\n\n');


### PR DESCRIPTION
#### Component/feature

Custom IML function unit testing

#### Issue

Custom IML functions shlould be available under `iml.` namespace. But by #114 they were incorrectly available without the namespace - as the global functions.

#### Fix

This PR fixes the placement of the custom IML functions and fixes the unit testing for this feature.