### PR TITLE
fix: recursive IML function unit testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
 			],
 			"sourceMaps": true,
-			"outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
 			"preLaunchTask": "npm: compile",
 		},
 		{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Unreleased
 
 ### Fixed
 
+- Custom IML function unit testing was not able to test recursive functions
+
+### Fixed
+
 - Custom IML function was not correctly available under the namespace `iml.` in another function's body.
 
 1.3.28 (pre-release)

--- a/src/commands/FunctionCommands.test.ts
+++ b/src/commands/FunctionCommands.test.ts
@@ -60,9 +60,8 @@ suite('IML Functions Unit testing feature', () => {
 		test('Unit test should report the success when expectation === actual', async () => {
 			await executeCustomFunctionTest(
 				sumFuncName,
-				sumFuncCode,
 				succesfulSumTestCode,
-				[],
+				[{ name: sumFuncName, code: sumFuncCode }],
 				outputChannel,
 				'Europe/Prague',
 			);
@@ -77,9 +76,8 @@ suite('IML Functions Unit testing feature', () => {
 		test('Unit test should report the fail when expectation !== actual', async () => {
 			await executeCustomFunctionTest(
 				sumFuncName,
-				sumFuncCode,
 				failingSumTestCode,
-				[],
+				[{ name: sumFuncName, code: sumFuncCode }],
 				outputChannel,
 				'Europe/Prague',
 			);
@@ -94,9 +92,8 @@ suite('IML Functions Unit testing feature', () => {
 		test('Multiple unit tests in one file', async () => {
 			await executeCustomFunctionTest(
 				sumFuncName,
-				sumFuncCode,
 				succesfulSumTestCode + failingSumTestCode,
-				[],
+				[{ name: sumFuncName, code: sumFuncCode }],
 				outputChannel,
 				'Europe/Prague',
 			);
@@ -108,13 +105,16 @@ suite('IML Functions Unit testing feature', () => {
 		const anotherCustomFunctions = [
 			{ name: 'getFive', code: 'function getFive() { return 5; }' },
 			{ name: 'getSix', code: 'function getSix() { return 6; }' },
+			{
+				name: 'fakeFunc3',
+				code: `function fakeFunc3() { return typeof iml.ceil === 'function' &&
+					typeof iml.omit === 'function' &&
+					typeof iml.capitalize === 'function' &&
+					typeof iml.addDays === 'function' &&
+					(iml.getFive() + iml.getSix());
+				}`,
+			},
 		];
-		const fakeFunc3Code = `function fakeFunc3() { return typeof iml.ceil === 'function' &&
-			typeof iml.omit === 'function' &&
-			typeof iml.capitalize === 'function' &&
-			typeof iml.addDays === 'function' &&
-			(iml.getFive() + iml.getSix());
-		}`;
 
 		test('Unit test should report the success when expectation === actual', async () => {
 			const fakeFunc3SucessfullTestCode = `it('simulatedTestAccessAnotherCustomFunc', () => {
@@ -123,7 +123,6 @@ suite('IML Functions Unit testing feature', () => {
 
 			await executeCustomFunctionTest(
 				'fakeFunc3',
-				fakeFunc3Code,
 				fakeFunc3SucessfullTestCode,
 				anotherCustomFunctions,
 				outputChannel,
@@ -145,7 +144,6 @@ suite('IML Functions Unit testing feature', () => {
 
 			await executeCustomFunctionTest(
 				'fakeFunc3',
-				fakeFunc3Code,
 				fakeFunc3FailingTestCode,
 				anotherCustomFunctions,
 				outputChannel,
@@ -162,8 +160,7 @@ suite('IML Functions Unit testing feature', () => {
 	});
 
 	test('Build-in functions are available and callable in custom functions', async () => {
-		const callImlCode =
-			`function callImlFunction() {
+		const callImlCode = `function callImlFunction() {
 				return typeof iml.ceil === 'function' &&
 					typeof iml.pick === 'function' &&
 					typeof iml.base64 === 'function' &&
@@ -177,9 +174,8 @@ suite('IML Functions Unit testing feature', () => {
 
 		await executeCustomFunctionTest(
 			'callImlFunction',
-			callImlCode,
 			callImlSucessfulTestCode,
-			[],
+			[{ name: 'callImlFunction', code: callImlCode }],
 			outputChannel,
 			'Europe/Prague',
 		);
@@ -192,9 +188,34 @@ suite('IML Functions Unit testing feature', () => {
 		assertTestSummary(outputChannel, 1, 0);
 	});
 
+	test('Custom function can be recursive', async () => {
+		const sumSequenceCode = `function sumSequence(n) {
+				if (n < 1) { return 0 };
+				return n + iml.sumSequence(n-1);
+			}`;
+
+		const imlTestCode = `it('testSumSequence', () => {
+			assert.equal(sumSequence(5), 15);
+		});`;
+
+		await executeCustomFunctionTest(
+			'sumSequence',
+			imlTestCode,
+			[{ name: 'sumSequence', code: sumSequenceCode }],
+			outputChannel,
+			'Europe/Prague',
+		);
+
+		assert.equal(
+			outputChannel._findLine('- testSumSequence'),
+			'- testSumSequence ... ✔',
+			'Test evaluated correctly',
+		);
+		assertTestSummary(outputChannel, 1, 0);
+	});
+
 	test('Unit test fail when called unexisting iml function', async () => {
-		const callImlCode =
-			`function callFailingImlFunction1() {
+		const callImlCode = `function callFailingImlFunction1() {
 				return iml.notExistFunction(1, 3, 5);
 			}`;
 
@@ -203,10 +224,9 @@ suite('IML Functions Unit testing feature', () => {
 		});`;
 
 		await executeCustomFunctionTest(
-			'callImlFunction',
-			callImlCode,
+			'callFailingImlFunction1',
 			callImlSucessfulTestCode,
-			[],
+			[{ name: 'callFailingImlFunction1', code: callImlCode }],
 			outputChannel,
 			'Europe/Prague',
 		);
@@ -219,7 +239,6 @@ suite('IML Functions Unit testing feature', () => {
 		assertTestSummary(outputChannel, 0, 1);
 	});
 
-
 	test('Timeout in case of function infinite loop', async () => {
 		const loopFuncCode = 'function loopingFunc(a, b) { while(true) {} }';
 		const failingLoopFuncTestCode = `it('loopingFunc should return undefined', () => {
@@ -227,9 +246,8 @@ suite('IML Functions Unit testing feature', () => {
 		});`;
 		await executeCustomFunctionTest(
 			'loopingFunc',
-			loopFuncCode,
 			failingLoopFuncTestCode,
-			[],
+			[{ name: 'loopingFunc', code: loopFuncCode }],
 			outputChannel,
 			'Europe/Prague',
 		);
@@ -252,9 +270,8 @@ suite('IML Functions Unit testing feature', () => {
 		});`;
 		await executeCustomFunctionTest(
 			'getProcess',
-			getProcessCode,
 			getProcessTestCode,
-			[],
+			[{ name: 'getProcess', code: getProcessCode }],
 			outputChannel,
 			'Europe/Prague',
 		);
@@ -273,9 +290,8 @@ suite('IML Functions Unit testing feature', () => {
 		});`;
 		await executeCustomFunctionTest(
 			'getGlobal',
-			getGlobalCode,
 			getGlobalTestCode,
-			[],
+			[{ name: 'getGlobal', code: getGlobalCode }],
 			outputChannel,
 			'Europe/Prague',
 		);

--- a/src/commands/FunctionCommands.ts
+++ b/src/commands/FunctionCommands.ts
@@ -98,13 +98,10 @@ export class FunctionCommands {
 				}
 			}
 
-			// Get current function code
-			const code = await Core.rpGet(`${urn}/${functionName}/code`, _authorization)
-
 			// Get current test code
 			const test = await Core.rpGet(`${urn}/${functionName}/test`, _authorization)
 
-			// Get users' functions
+			// Get all custom IML functions (includes the tested one)
 			let userFunctions: CustomImlFunction[] = await Core.rpGet(`${urn}`, _authorization, { code: true, cols: ['name', 'code'] })
 			if (_environment.version === 2) {
 				userFunctions = (<any>userFunctions).appFunctions;
@@ -112,7 +109,7 @@ export class FunctionCommands {
 
 			// Merge codes
 
-			await executeCustomFunctionTest(functionName, code, test, userFunctions, outputChannel, _timezone);
+			await executeCustomFunctionTest(functionName, test, userFunctions, outputChannel, _timezone);
 
 		})
 	}
@@ -123,12 +120,9 @@ export class FunctionCommands {
  * and pushes the result into `outputChannel` as user-friendly report.
  */
 export async function executeCustomFunctionTest(
-	functionName: string, customFunctionCode: string, testCode: string,
+	functionNameForTesting: string, testCode: string,
 	allCustomImlFunctions: CustomImlFunction[], outputChannel: vscode.OutputChannel, _timezone: string
 ) {
-
-	const codeToRun = `${customFunctionCode}\r\n\r\n/* === TEST CODE === */\r\n\r\n${testCode}`
-
 	/**
 	 *  Sandbox cookbook
 	 *  - Assert for assertions
@@ -168,7 +162,7 @@ export async function executeCustomFunctionTest(
 
 	outputChannel.appendLine(
 		'======= STARTING IML TEST =======\r\n' +
-		`Function: ${functionName}\r\n` +
+		`Function: ${functionNameForTesting}\r\n` +
 		'---------- IN PROGRESS ----------',
 	);
 	// Give a time to display the output log
@@ -181,18 +175,19 @@ export async function executeCustomFunctionTest(
 	// because the tested function can call other functions anytime.
 	const customImlFunctionsCode = allCustomImlFunctions
 		.map((userFunction) => {
-			if (userFunction.name !== functionName) {
-				return `iml['${userFunction.name}'] = function (...arguments) {` +
-					`    return (${userFunction.code}).apply({timezone: environment.timezone}, arguments); ` +
-					'};';
-			}
+			return `iml['${userFunction.name}'] = function (...arguments) {` +
+				`    return (${userFunction.code}).apply({timezone: environment.timezone}, arguments); ` +
+				'};';
 		})
 		.join('\n\n');
 	vm.runInContext(customImlFunctionsCode, sandbox, { timeout: 2000 });
 
 	// Execute the test
 	try {
-		vm.runInContext(codeToRun, sandbox, { timeout: 5000 });
+		// Make the tested function available in global scope (without `iml.` prefix)
+		vm.runInContext(`const ${functionNameForTesting} = iml.${functionNameForTesting};`, sandbox, { timeout: 1000 });
+		// Execute tests
+		vm.runInContext(testCode, sandbox, { timeout: 5000 });
 		outputChannel.appendLine('----------- FINISHED -----------');
 		outputChannel.appendLine(`Total test blocks: ${total}`);
 		outputChannel.appendLine(`Passed blocks: ${success}`);


### PR DESCRIPTION
Fixing issue:

When tested function was recursive, the unit test started to fail, becuse it was not able to call itself in the custom IML function body.

Other changes:

Minor simplification of testing alghoritm input parameters.