### PR TITLE
fix: improve error message handling

### DIFF
--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -6,47 +6,61 @@ import { log, showLog } from './output-channel';
  * Smart convert a varios types of errors to string.
  */
 export function errorToString(err: Error | AxiosError<any> | string): { message: string; isImproved: boolean } {
-	const errMessages: string[] = [];
+	try {
+		const errMessages: string[] = [];
 
-	if (typeof err === 'string') {
-		errMessages.push(err);
-	}
-
-	// #region Case of the Error toast notification
-	else if (err instanceof AxiosError) {
-		// Try to use APIError message format instead of syntax error
-		if (err.response?.data?.suberrors instanceof Array && err.response.data.suberrors.length > 0) {
-			errMessages.push(
-				...(err.response.data.suberrors as { message: string }[]).map((suberror) => suberror.message),
-			);
-		} else if (err.response?.data?.detail) {
-			// No suberrors exist
-			const detailMessage = `${
-				err.response.data.detail instanceof Array ? err.response.data.detail[0] : err.response.data.detail
-			}`;
-			errMessages.push(detailMessage);
-		} else if (err.response?.data.message) {
-			errMessages.push(err.response.data.message);
-		} else if (typeof err.response?.data === 'string') {
-			// Axios can return JSON error message stringified, so try to parse them.
-			errMessages.push(String(err.response.data));
-		} else {
-			errMessages.push(err.response?.status + ' ' + (err.response?.statusText ?? 'Unknown response error'));
+		if (typeof err === 'string') {
+			errMessages.push(err);
 		}
-	} else if (err instanceof Error && err.message) {
-		errMessages.push(err.message);
-	} else if (err instanceof Object) {
-		errMessages.push(JSON.stringify(err));
-	} else {
-		errMessages.push(String(err));
+
+		// #region Case of the Error toast notification
+		else if (err instanceof AxiosError) {
+			// Use error `detail` + `suberrors`, which are used by Make API as part of error responses.
+			const hasSuberrors =
+				err.response?.data?.suberrors instanceof Array && err.response.data.suberrors.length > 0;
+			if (err.response?.data?.detail || hasSuberrors) {
+				if (err.response?.data?.detail) {
+					const detailMessages: string[] =
+						err.response.data.detail instanceof Array
+							? err.response.data.detail
+							: [err.response.data.detail];
+					errMessages.push(...detailMessages.map((m) => String(m)));
+				}
+				if (hasSuberrors) {
+					errMessages.push(
+						...(err.response!.data.suberrors as { message: string }[]).map((suberror) => suberror.message),
+					);
+				}
+			} else if (err.response?.data.message) {
+				errMessages.push(err.response.data.message);
+			} else if (typeof err.response?.data === 'string') {
+				// Axios can return JSON error message stringified, so try to parse them.
+				errMessages.push(String(err.response.data));
+			} else {
+				errMessages.push(err.response?.status + ' ' + (err.response?.statusText ?? 'Unknown response error'));
+			}
+		} else if (err instanceof Error && err.message) {
+			errMessages.push(err.message);
+		} else if (err instanceof Object) {
+			errMessages.push(JSON.stringify(err));
+		} else {
+			errMessages.push(String(err));
+		}
+
+		const improved = improveSomeErrors(errMessages);
+
+		return {
+			message: improved.messages.join(' - '),
+			isImproved: improved.isImproved,
+		};
+	} catch (e: any) {
+		/*
+		 * To avoid an infinit loop in case of internal error,
+		 * it is needed to handle exception and have the stupid solution as fallback.
+		 *
+		 */
+		return (err as any)?.message ?? err;
 	}
-
-	const improved = improveSomeErrors(errMessages);
-
-	return {
-		message: improved.messages.join(' - '),
-		isImproved: improved.isImproved,
-	};
 }
 
 /**
@@ -136,6 +150,21 @@ function getImprovedErrorMessage(message: string): string | undefined {
 	if (message.includes(' in JSONC at position ')) {
 		return 'JSON has corrupted structure. Code cannot be deployed. Find and fix the error and try to deploy again.';
 	}
+
+	// TODO Keep until the bug `CDM-10287` not resolved, then remove.
+	if (message === 'Primary connection must not be the same as the alternative one.') {
+		return (
+			message +
+			' THIS ERROR MESSAGE CAN BE THE PART OF THE KNOWN BUG. Workaround: Try to change "connection" and "alternative connection" one by one, not together.'
+		);
+	}
+	if (message === 'Connection cannot be deleted when alternative connection exists.') {
+		return (
+			message +
+			' THIS ERROR MESSAGE CAN BE THE PART OF THE KNOWN BUG. Workaround: Try to remove the "alternative connection" separately first.'
+		);
+	}
+
 	return undefined;
 }
 


### PR DESCRIPTION
Issue:

When API responded error with `detail` and `suberrors` properties together, then `detail` has been ignored and was missing in the final error message

Fix:

Merge `detail` and `suberrors` error messages together in output error message.