### PR TITLE
fix: make module description mandatory

### DIFF
--- a/src/local-development/create-local-module.ts
+++ b/src/local-development/create-local-module.ts
@@ -47,8 +47,8 @@ async function onCreateLocalModuleClick(file: vscode.Uri) {
 	// Ask for module description
 	const moduleDescription = await askFreeText({
 		subject: 'Description of new module to be created',
-		note: 'Rules: Optional. Use any free text.',
-		required: false,
+		note: 'Rules: Use any free text, but must not be empty.',
+		required: true,
 	});
 	if (moduleDescription === undefined) {
 		return; /* Cancelled by user */


### PR DESCRIPTION
Issue: The description is incorrectly marked as optional in the creation wizard. But in Make it is mandatory.