### PR TITLE
fix: action module "crud" as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+1.3.55 (pre-release) [2024-05-13]
+--------------------
+
+- Fix: Action modules have the `crud` as optional only now.
+
 1.3.54 (pre-release) [2024-05-02]
 --------------------
 

--- a/src/local-development/create-local-empty-component.ts
+++ b/src/local-development/create-local-empty-component.ts
@@ -25,9 +25,9 @@ export async function createLocalEmptyComponent(
 					`Cannot create local ${componentType}, because missing "componentMetadata.moduleType", but it is required for ${componentType} ${preferedComponentLocalId} creation.`,
 				);
 			}
-			if (componentMetadata.moduleType === 'action' && !componentMetadata.actionCrud) {
+			if (componentMetadata.moduleType === 'action' && componentMetadata.actionCrud === undefined) {
 				throw new Error(
-					`Cannot create local ${componentType}, because missing "componentMetadata.actionCrud", but it is required for ${componentType} ${preferedComponentLocalId} creation.`,
+					`Cannot create local ${componentType}, because missing "componentMetadata.actionCrud", but it is required to be defined for ${componentType} ${preferedComponentLocalId} creation.`,
 				);
 			}
 			break;


### PR DESCRIPTION
change:

- Fix: Action modules have the `crud` as optional only now.