### PR TITLE
feat: exclude common data from from local development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+- During the app clone a user chooses to exclude or include the app common data. If common data are included, they are also committed to GIT.
+- Common data file are not being added to `.gitignore` anymore.
+
 1.3.55 (pre-release) [2024-05-14]
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Change Log
 ==========
 
-- During the app clone a user chooses to exclude or include the app common data. If common data are included, they are also committed to GIT.
-- Common data file are not being added to `.gitignore` anymore.
+- During the app clone a user chooses to exclude or include the app's common data. If common data are included, they are also committed to GIT.
+- Common data files are not being added to `.gitignore` anymore.
 
 1.3.55 (pre-release) [2024-05-14]
 --------------------

--- a/README-apps-local-development.md
+++ b/README-apps-local-development.md
@@ -193,5 +193,3 @@ The local development feature is fully compatible with GIT. Use `git init` at an
 During the app clone to the local workspace, the `.gitignore` file is created automatically with the following files to exclude from GIT:
 
 - `.secret` directory, because contains the private API key(s).
-- `common.js` general code file, because it can contain some secrets or other private data.
-- `*.common.js` connection code file, because it can contain some secrets or other private data.

--- a/src/local-development/clone.ts
+++ b/src/local-development/clone.ts
@@ -75,7 +75,7 @@ async function cloneAppToWorkspace(context: App): Promise<void> {
 				'COMMON DATA INCLUDE/EXCLUDE:' +
 				'\n\n' +
 				'Common data could contain sensitive data or secrets. It depends on your app design. ' +
-				'We recommended to exclude common data files from the app local clone. ' +
+				'We recommend that you exclude common data files from the local clone of the application. ' +
 				'If you are decide to include it, be aware that these common data files will be also the part of your GIT commits.',
 		},
 		{ title: 'Exclude (more safe)' },

--- a/src/local-development/clone.ts
+++ b/src/local-development/clone.ts
@@ -135,10 +135,10 @@ async function cloneAppToWorkspace(context: App): Promise<void> {
 		origins: [originWithoutApiKey],
 	};
 
-	// Save .gitignore: exclude secrets dir, common data.
+	// Save .gitignore: exclude secrets dir.
 	const gitignoreUri = vscode.Uri.joinPath(workspaceRoot, '.gitignore');
 	const secretsDirRelativeToWorkspaceRoot = path.posix.relative(workspaceRoot.path, apikeyDir.path);
-	const gitignoreLines: string[] = ['common.json', '*.common.json', secretsDirRelativeToWorkspaceRoot];
+	const gitignoreLines: string[] = [secretsDirRelativeToWorkspaceRoot];
 	const gitignoreContent = new TextEncoder().encode(gitignoreLines.join('\n') + '\n');
 	await vscode.workspace.fs.writeFile(gitignoreUri, gitignoreContent);
 	// Create apikey file

--- a/src/local-development/clone.ts
+++ b/src/local-development/clone.ts
@@ -78,7 +78,7 @@ async function cloneAppToWorkspace(context: App): Promise<void> {
 				'We recommend that you exclude common data files from the local clone of the application. ' +
 				'If you decide to include it, be aware that these common data files will also be part of your GIT commits.',
 		},
-		{ title: 'Exclude (more safe)' },
+		{ title: 'Exclude (more secure)' },
 		{ title: 'Include (for advanced users only)' },
 	);
 	if (!commonDataAnswer) {

--- a/src/local-development/clone.ts
+++ b/src/local-development/clone.ts
@@ -76,7 +76,7 @@ async function cloneAppToWorkspace(context: App): Promise<void> {
 				'\n\n' +
 				'Common data could contain sensitive data or secrets. It depends on your app design. ' +
 				'We recommend that you exclude common data files from the local clone of the application. ' +
-				'If you are decide to include it, be aware that these common data files will be also the part of your GIT commits.',
+				'If you decide to include it, be aware that these common data files will also be part of your GIT commits.',
 		},
 		{ title: 'Exclude (more safe)' },
 		{ title: 'Include (for advanced users only)' },

--- a/src/local-development/code-pull-deploy.ts
+++ b/src/local-development/code-pull-deploy.ts
@@ -174,8 +174,12 @@ export async function pullComponentCodes(
 	sendTelemetry('pull_component_codes', { appComponentType, remoteComponentName });
 
 	// Download codes from API to local files
-	for (const [codeType, codeLocalRelativePath] of entries(componentMetadata.codeFiles)) {
-		const codeLocalAbsolutePath = vscode.Uri.joinPath(localAppRootdir, codeLocalRelativePath);
+	for (const [codeType, codeFilePath] of entries(componentMetadata.codeFiles)) {
+		if (codeFilePath === null) {
+			// Skip the ignored component code
+			continue;
+		}
+		const codeLocalAbsolutePath = vscode.Uri.joinPath(localAppRootdir, codeFilePath);
 		await pullComponentCode({
 			appComponentType,
 			remoteComponentName,

--- a/src/local-development/groups-json.ts
+++ b/src/local-development/groups-json.ts
@@ -9,11 +9,13 @@ const limitConcurrency = throat(1);
  * Default target group is `Other` if exists, else the last one.
  */
 export async function optionalAddModuleToDefaultGroup(anyProjectPath: vscode.Uri, newModuleID: string): Promise<void> {
+	const groupsCodeFilePath = (await getMakecomappJson(anyProjectPath)).generalCodeFiles.groups;
+	if (groupsCodeFilePath === null) {
+		// Do not do anything if the groups file is being ignored in project.
+		return;
+	}
 	const makeappRootdir = getMakecomappRootDir(anyProjectPath);
-	const groupsCodeUri = vscode.Uri.joinPath(
-		makeappRootdir,
-		(await getMakecomappJson(makeappRootdir)).generalCodeFiles.groups,
-	);
+	const groupsCodeUri = vscode.Uri.joinPath(makeappRootdir, groupsCodeFilePath);
 
 	await limitConcurrency(async () => {
 		// Load the groups.json file content

--- a/src/local-development/helpers/custom-app-local-project-class.ts
+++ b/src/local-development/helpers/custom-app-local-project-class.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { MakecomappJsonFile } from './makecomapp-json-file-class';
+
+/**
+ * Class based logic around Local App Development.
+ *
+ * TODO: The idea is to refactor some node modules from stand-alone non-class functions into class based structure.
+ */
+export class CustomAppLocalProject {
+	constructor(private readonly anyProjectPath: vscode.Uri) {}
+
+	async isCommonDataIncluded(): Promise<boolean> {
+		return (await this.getFreshMakecomappJson()).isCommonDataIncluded;
+	}
+
+	async getFreshMakecomappJson() {
+		return await MakecomappJsonFile.fromLocalProject(this.anyProjectPath);
+	}
+}

--- a/src/local-development/helpers/makecomapp-json-file-class.ts
+++ b/src/local-development/helpers/makecomapp-json-file-class.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { getMakecomappJson } from '../makecomappjson';
+import { MakecomappJson } from '../types/makecomapp.types';
+
+/**
+ * Represents the content of `makecomapp.json` and methods, which are possible to execute over this content.
+ *
+ * TODO: The idea is to refactor some node modules from stand-alone non-class functions into class based structure.
+ */
+export class MakecomappJsonFile {
+	/**
+	 * @param content The in-memory representation of `makecomapp.json` file content.
+	 */
+	private constructor(public content: MakecomappJson, private anyProjectPath: vscode.Uri) {}
+
+	/**
+	 * Creates new class instance with the fresly loaded file content.
+	 * @param anyProjectPath
+	 * @returns New class instance
+	 */
+	public static async fromLocalProject(anyProjectPath: vscode.Uri): Promise<MakecomappJsonFile> {
+		const content = await getMakecomappJson(anyProjectPath);
+		return new MakecomappJsonFile(content, anyProjectPath);
+	}
+
+	/**
+	 * Gets whether the project contains the common data or ignores it.
+	 * The decision is based on including or excluding app common data file.
+	 */
+	public get isCommonDataIncluded(): boolean {
+		return Boolean(this.content.generalCodeFiles.common);
+	}
+}

--- a/src/local-development/helpers/makecomapp-json-file-class.ts
+++ b/src/local-development/helpers/makecomapp-json-file-class.ts
@@ -14,7 +14,7 @@ export class MakecomappJsonFile {
 	private constructor(public content: MakecomappJson, private anyProjectPath: vscode.Uri) {}
 
 	/**
-	 * Creates new class instance with the fresly loaded file content.
+	 * Creates new class instance with the freshly loaded file content.
 	 * @param anyProjectPath
 	 * @returns New class instance
 	 */

--- a/src/local-development/local-file-paths.ts
+++ b/src/local-development/local-file-paths.ts
@@ -78,7 +78,7 @@ export async function generateComponentDefaultCodeFilesPaths(
 	for (const [codeType, codeDef] of componentCodesDef) {
 		if (codeType === 'common' && !includeCommonFiles) {
 			// Ignore the common data file, because required to ignore
-			componentCodeMetadata[codeType] === null;
+			componentCodeMetadata[codeType] = null;
 		} else {
 			// Local file path (Relative to app rootdir)
 			const codeFilename = await generateDefaultLocalFilename(

--- a/src/local-development/local-file-paths.ts
+++ b/src/local-development/local-file-paths.ts
@@ -64,6 +64,7 @@ export async function generateComponentDefaultCodeFilesPaths(
 	componentLocalId: string,
 	componentMetadata: AppComponentMetadata,
 	localAppRootdir: vscode.Uri,
+	includeCommonFiles: boolean,
 ): Promise<ComponentCodeFilesMetadata> {
 	const componentDir = await reserveComponentCodeFilesDirectory(componentType, componentLocalId, localAppRootdir);
 
@@ -75,16 +76,21 @@ export async function generateComponentDefaultCodeFilesPaths(
 	const componentCodeMetadata: ComponentCodeFilesMetadata = {};
 	// Process all codes
 	for (const [codeType, codeDef] of componentCodesDef) {
-		// Local file path (Relative to app rootdir)
-		const codeFilename = await generateDefaultLocalFilename(
-			codeDef,
-			codeType,
-			componentType,
-			componentLocalId,
-			componentMetadata,
-		);
-		componentCodeMetadata[codeType] =
-			path.posix.relative(localAppRootdir.path, componentDir.path) + '/' + codeFilename;
+		if (codeType === 'common' && !includeCommonFiles) {
+			// Ignore the common data file, because required to ignore
+			componentCodeMetadata[codeType] === null;
+		} else {
+			// Local file path (Relative to app rootdir)
+			const codeFilename = await generateDefaultLocalFilename(
+				codeDef,
+				codeType,
+				componentType,
+				componentLocalId,
+				componentMetadata,
+			);
+			componentCodeMetadata[codeType] =
+				path.posix.relative(localAppRootdir.path, componentDir.path) + '/' + codeFilename;
+		}
 	}
 	return componentCodeMetadata;
 }

--- a/src/local-development/local-file-paths.ts
+++ b/src/local-development/local-file-paths.ts
@@ -77,7 +77,7 @@ export async function generateComponentDefaultCodeFilesPaths(
 	// Process all codes
 	for (const [codeType, codeDef] of componentCodesDef) {
 		if (codeType === 'common' && !includeCommonFiles) {
-			// Ignore the common data file, because required to ignore
+			// common data files were selected to ignore
 			componentCodeMetadata[codeType] = null;
 		} else {
 			// Local file path (Relative to app rootdir)

--- a/src/local-development/pull.ts
+++ b/src/local-development/pull.ts
@@ -5,13 +5,14 @@ import {
 	ComponentCodeFilesMetadata,
 	LocalAppOriginWithSecret,
 } from './types/makecomapp.types';
-import { getMakecomappJson, getMakecomappRootDir, upsertComponentInMakecomappjson } from './makecomappjson';
+import { getMakecomappRootDir, upsertComponentInMakecomappjson } from './makecomappjson';
 import { convertComponentMetadataRemoteNamesToLocalIds, getRemoteComponentsSummary } from './remote-components-summary';
 import { generateComponentDefaultCodeFilesPaths } from './local-file-paths';
 import { pullComponentCode, pullComponentCodes } from './code-pull-deploy';
 import { askForProjectOrigin } from './ask-origin';
 import { alignComponentsMapping } from './align-components-mapping';
 import { ComponentIdMappingHelper } from './helpers/component-id-mapping-helper';
+import { MakecomappJsonFile } from './helpers/makecomapp-json-file-class';
 import { generalCodesDefinition, getAppComponentTypes } from '../services/component-code-def';
 import { AppComponentType } from '../types/app-component-type.types';
 import { catchError } from '../error-handling';
@@ -58,11 +59,15 @@ export async function pullAllComponents(
 		newRemoteComponentResolution,
 	);
 	// Load fresh `makecomapp.json` file (because `alignComponentMapping()` changed it)
-	const makecomappJson = await getMakecomappJson(localAppRootdir);
+	const makecomappJsonFile = await MakecomappJsonFile.fromLocalProject(localAppRootdir);
 
 	// Pull app general codes
 	for (const [codeType] of entries(generalCodesDefinition)) {
-		const codeLocalRelativePath = makecomappJson.generalCodeFiles[codeType];
+		const codeLocalRelativePath = makecomappJsonFile.content.generalCodeFiles[codeType];
+		if (codeLocalRelativePath === null) {
+			// Skip ignored component codes.
+			continue;
+		}
 		const codeLocalAbsolutePath = vscode.Uri.joinPath(localAppRootdir, codeLocalRelativePath);
 		// Pull code from API to local file
 		await pullComponentCode({
@@ -77,7 +82,7 @@ export async function pullAllComponents(
 	// Pull app components from remote
 	// Note: All remote components have already existing local counterparties because of previously called `alignComponentsMapping()`.
 	for (const componentType of getAppComponentTypes()) {
-		const componentIdMapping = new ComponentIdMappingHelper(makecomappJson, origin);
+		const componentIdMapping = new ComponentIdMappingHelper(makecomappJsonFile.content, origin);
 		for (const [remoteComponentName, remoteComponentMetadata] of Object.entries(
 			remoteAppComponentsSummary[componentType],
 		)) {
@@ -86,7 +91,7 @@ export async function pullAllComponents(
 				continue;
 				// Because the mapping defines this remote component as "ignore".
 			}
-			const existingComponentMetadata = makecomappJson.components[componentType][componentLocalId];
+			const existingComponentMetadata = makecomappJsonFile.content.components[componentType][componentLocalId];
 			if (!existingComponentMetadata) {
 				throw new Error(
 					`Local ${componentType} "${componentLocalId}" expected, but not found in 'makecomapp.json'. Unexpected Error.`,
@@ -108,6 +113,7 @@ export async function pullAllComponents(
 				updatedComponentMedatada,
 				localAppRootdir,
 				origin,
+				makecomappJsonFile.isCommonDataIncluded,
 			);
 		}
 	}
@@ -127,8 +133,10 @@ async function pullComponent(
 	updatedComponentMetadata: AppComponentMetadata | AppComponentMetadataWithCodeFiles,
 	localAppRootdir: vscode.Uri,
 	origin: LocalAppOriginWithSecret,
+	includeCommonFiles: boolean,
 ) {
-	// Generate code files paths if local component does not exist yet
+	// Generate code files paths if local component does not exist yet.
+	//   (In this case the `updatedComponentMetadata` param value is being provided without `codeFiles`.)
 	const existingLocalCodeFiles: ComponentCodeFilesMetadata | undefined = (
 		updatedComponentMetadata as AppComponentMetadataWithCodeFiles
 	).codeFiles;
@@ -141,6 +149,7 @@ async function pullComponent(
 				componentLocalId,
 				updatedComponentMetadata,
 				localAppRootdir,
+				includeCommonFiles,
 			)),
 	};
 

--- a/src/local-development/pull.ts
+++ b/src/local-development/pull.ts
@@ -80,7 +80,7 @@ export async function pullAllComponents(
 	}
 
 	// Pull app components from remote
-	// Note: All remote components have already existing local counterparties because of previously called `alignComponentsMapping()`.
+	// Note: All remote components already have local counterparts due to previously called `alignComponentsMapping()`.
 	for (const componentType of getAppComponentTypes()) {
 		const componentIdMapping = new ComponentIdMappingHelper(makecomappJsonFile.content, origin);
 		for (const [remoteComponentName, remoteComponentMetadata] of Object.entries(

--- a/src/local-development/types/makecomapp.types.ts
+++ b/src/local-development/types/makecomapp.types.ts
@@ -91,11 +91,21 @@ export interface AppComponentMetadata {
 	webhook?: string | null;
 }
 
-/** General Code Type => Code Local File Path */
-export type GeneralCodeFilesMetadata = Record<GeneralCodeType, CodeFilePath>;
+/**
+ * General Code Type => Code Local File Path.
+ *
+ *  If `CodeFilePath` is `null`, it means the code is being ignored in local development (during pulls and deployments).
+ *  The `null` used primarly for common data in case a developer decided to not include common data in local project.
+ */
+export type GeneralCodeFilesMetadata = Record<GeneralCodeType, CodeFilePath | null>;
 
-/** Component's Code Type => Code Local File Path */
-export type ComponentCodeFilesMetadata = Partial<Record<ComponentCodeType, CodeFilePath>>;
+/**
+ * Component's Code Type => Code Local File Path
+ *
+ *  If `CodeFilePath` is `null`, it means the code is being ignored in local development (during pulls and deployments).
+ *  The `null` used primarly for common data in case a developer decided to not include common data in local project.
+ */
+export type ComponentCodeFilesMetadata = Partial<Record<ComponentCodeType, CodeFilePath | null>>;
 
 /**
  * Relative filepath in local filesystem.


### PR DESCRIPTION
## Changes 

- During the app clone a user chooses to exclude or include the app's common data. If common data are included, they are also committed to GIT.
- Common data files are not being added to `.gitignore` anymore.