### PR TITLE
fix: creation of universal module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 
 - Fixed missing API error response message, where incorrect `response: [object Object]` was displayed instead of actual response.
+- Fixed creation of universal module.
 
 1.3.56 (pre-release) [2024-05-23]
 --------------------

--- a/src/local-development/create-local-module.ts
+++ b/src/local-development/create-local-module.ts
@@ -63,6 +63,27 @@ async function onCreateLocalModuleClick(file: vscode.Uri) {
 		return;
 	}
 
+	// Universal module: Ask for mandatory subtype
+	/*
+	 * // Note: Not needed until modules are created empty (without defaulty template).
+	 * //       Code is prepared for feature, where local module will be created with code templates.
+	 *
+	 * // Note: Subtype defines only, which default template will used for universal module creation.
+	 *
+	 * type UniversalModuleSubtype = 'Universal' | 'UniversalGraphQL';
+	 *
+	 * let universalModuleSubtype: 'UniversalModuleSubtype' | undefined;
+	 * if (moduleTypePick.id === 'universal') {
+	 * 	const universalModuleSubtypePick = await vscode.window.showQuickPick(universalModuleSubtypes, {
+	 * 		placeHolder: 'Select the subtype of universal module (mandatory)',
+	 * 	});
+	 * 	if (!universalModuleSubtypePick) {
+	 * 		return;
+	 * 	}
+	 * 	universalModuleSubtype = universalModuleSubtypePick.description as UniversalModuleSubtype; // Note: Actually, the `description` field contains an ID.
+	 * }
+	 */
+
 	// Instant trigger: Ask for mandatory webhook
 	let instantTriggerWebhookLocalId: string | undefined = undefined;
 	if (moduleTypePick.id === 'instant_trigger') {

--- a/src/local-development/create-remote-component.ts
+++ b/src/local-development/create-remote-component.ts
@@ -63,6 +63,15 @@ export async function createRemoteAppComponent(opt: {
 						}", but missing. Check the ${MAKECOMAPP_FILENAME}.`,
 					);
 				}
+
+				// For Universal Module: Add the mandatory `subtype` property.
+				//   Note: Defines, which template will be used for a new module.
+				//         The default server side template will owerride the template by local code files immediately
+				//         after component creation, therefore logic will work regardless what value will be used.
+				//         But the property `subtype` is mandatory in API, therefore any value must be filled.
+				if (opt.componentMetadata.moduleType === 'universal') {
+					axiosConfig.data.subtype = 'Universal' as 'Universal' | 'UniversalGraphQL';
+				}
 				break;
 
 			case 'connection':


### PR DESCRIPTION
Change:

Fixes the situation, where was impossible to create a universal module in Make, because of the missing `subtype` property in API.