### PR TITLE
use iml.jsonc instead of iml.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,21 +31,24 @@
 			{
 				"fileMatch": [
 					"parameters.imljson",
-					"*.params.iml.json"
+					"*.params.iml.json",
+					"*.params.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/parameters.json"
 			},
 			{
 				"fileMatch": [
 					"expect.imljson",
-					"*.mappable-params.iml.json"
+					"*.mappable-params.iml.json",
+					"*.mappable-params.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/parameters.json"
 			},
 			{
 				"fileMatch": [
 					"interface.imljson",
-					"*.interface.iml.json"
+					"*.interface.iml.json",
+					"*.interface.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/parameters.json"
 			},
@@ -59,21 +62,24 @@
 			{
 				"fileMatch": [
 					"api.imljson",
-					"*.communication.iml.json"
+					"*.communication.iml.json",
+					"*.communication.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/api.json"
 			},
 			{
 				"fileMatch": [
 					"samples.imljson",
-					"*.samples.iml.json"
+					"*.samples.iml.json",
+					"*.samples.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/samples.json"
 			},
 			{
 				"fileMatch": [
 					"scopes.imljson",
-					"*.scope-list.iml.json"
+					"*.scope-list.iml.json",
+					"*.scope-list.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/scopes.json"
 			},
@@ -81,49 +87,57 @@
 				"fileMatch": [
 					"scope.imljson",
 					"*.default-scope.iml.json",
-					"*.required-scope.iml.json"
+					"*.default-scope.iml.jsonc",
+					"*.required-scope.iml.json",
+					"*.required-scope.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/scope.json"
 			},
 			{
 				"fileMatch": [
 					"epoch.imljson",
-					"*.epoch.iml.json"
+					"*.epoch.iml.json",
+					"*.epoch.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/epoch.json"
 			},
 			{
 				"fileMatch": [
 					"attach.imljson",
-					"*.attach.iml.json"
+					"*.attach.iml.json",
+					"*.attach.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/api.json"
 			},
 			{
 				"fileMatch": [
 					"detach.imljson",
-					"*.detach.iml.json"
+					"*.detach.iml.json",
+					"*.detach.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/api.json"
 			},
 			{
 				"fileMatch": [
 					"publish.imljson",
-					"*.publish.iml.json"
+					"*.publish.iml.json",
+					"*.publish.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/api.json"
 			},
 			{
 				"fileMatch": [
 					"base.imljson",
-					"base.iml.json"
+					"base.iml.json",
+					"base.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/base.json"
 			},
 			{
 				"fileMatch": [
 					"api-oauth.imljson",
-					"*.oauth-communication.iml.json"
+					"*.oauth-communication.iml.json",
+					"*.oauth-communication.iml.jsonc"
 				],
 				"url": "./syntaxes/imljson/schemas/api-oauth.json"
 			},
@@ -139,7 +153,8 @@
 				"id": "imljson",
 				"extensions": [
 					".imljson",
-					".iml.json"
+					".iml.json",
+					".iml.jsonc"
 				],
 				"aliases": [
 					"JSON with IML",
@@ -794,7 +809,7 @@
 				{
 					"command": "apps-sdk.local-dev.file-compare",
 					"group": "7_modification",
-					"when": "resourceFilename =~ /^((README\\.md)|(base\\.iml\\.json)|(common\\.json)|(groups\\.json)|(.*\\.common\\.json)|(.*\\.(communication|oauth-communication|params|scope-list|default-scope|install-spec|install-directives|attach|detach|update|required|scope|epoch|static-params|mappable-params|interface|samples)\\.iml.json))|(.*\\.(code|test)\\.js)$/"
+					"when": "resourceFilename =~ /^((README\\.md)|(base\\.iml\\.jsonc?)|(common\\.json)|(groups\\.json)|(.*\\.common\\.json)|(.*\\.(communication|oauth-communication|params|scope-list|default-scope|install-spec|install-directives|attach|detach|update|required|scope|epoch|static-params|mappable-params|interface|samples)\\.iml.jsonc?))|(.*\\.(code|test)\\.js)$/"
 				},
 				{
 					"command": "apps-sdk.local-dev.create-local-connection",

--- a/src/services/component-code-def.ts
+++ b/src/services/component-code-def.ts
@@ -5,7 +5,7 @@ import { ComponentCodeType, GeneralCodeType } from '../local-development/types/c
 import { keys } from '../utils/typed-object';
 
 const imljsonc = {
-	fileext: 'iml.json',
+	fileext: 'iml.jsonc',
 	mimetype: 'application/jsonc',
 };
 


### PR DESCRIPTION
Amazing product. Love it!

But files created in JSONC format use the .json extension.
The file ends up in an invalid format, causing errors:
<details>
<summary>GitLab shows an error</summary>
<img width="593" alt="image" src="https://github.com/user-attachments/assets/aa509595-fc0d-46e5-a171-5fb7b0f034c0">
</details>
<details>
<summary>All other editors show an error as well</summary>
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/2b76819b-f663-4fbf-ae70-d2f222302ef4">
</details>

When I manually change the file extension, everything works fine, but the syntax highlighting in VSCode stops working.

This PR fixes it with a failover for the old variant.