### PR TITLE
fix(highlighting): fixed highlighting of spread op {{...}}

### DIFF
--- a/syntaxes/imljson/imljson.tmLanguage
+++ b/syntaxes/imljson/imljson.tmLanguage
@@ -350,7 +350,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>{{.+}}</string>
+					<string>{{.+?}}</string>
 					<key>name</key>
 					<string>entity.name.function</string>
 				</dict>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/48d855f2-b4fc-45d2-a66a-aa165c468451)

Topic: Spread operator {{...}} breaks syntax-highlight