### PR TITLE
docs: replace broken link to Make's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ _See more in [Local Development for Apps documentation](https://github.com/integ
 
 ## Documentation
 
-**Read more how to [create your custom Make app](https://docs.integromat.com/apps/).**
+**Read more how to [create your custom Make app](https://docs.make.com/apps/).**


### PR DESCRIPTION
The link in the article is still pointing to the former Integromat's documentation.