### PR TITLE
feat: add action to remove component dependencies on deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Added interface type='banner' into JSON schema.
+- Added feature "delete component".
 
 2.1.0 [2024-10-09]
 ------------------

--- a/package.json
+++ b/package.json
@@ -835,7 +835,7 @@
 				{
 					"command": "apps-sdk.local-dev.delete-local-component",
 					"group": "7_modification",
-					"when": "resourcePath =~ /^.*\\/(modules|connections|rpcs|webhooks)\\/[^\\/]+$/ && resourceExtname == ''"
+					"when": "resourcePath =~ /^.*\\/(modules|connections|rpcs|webhooks|functions)\\/[^\\/]+$/ && resourceExtname == ''"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -446,6 +446,11 @@
 			{
 				"command": "apps-sdk.local-dev.pull-all-components",
 				"title": "Pull All Components From Make (beta)"
+			},
+			{
+				"command": "apps-sdk.local-dev.delete-local-component",
+				"title": "Delete Component (beta)",
+				"category": "Make Apps"
 			}
 		],
 		"viewsContainers": {
@@ -826,6 +831,11 @@
 					"command": "apps-sdk.local-dev.create-local-imlfunction",
 					"group": "7_modification",
 					"when": "resourceFilename == 'makecomapp.json' || resourceFilename == 'functions'"
+				},
+				{
+					"command": "apps-sdk.local-dev.delete-local-component",
+					"group": "7_modification",
+					"when": "resourcePath =~ /^.*\\/(modules|connections|rpcs|webhooks)\\/[^\\/]+$/ && resourceExtname == ''"
 				}
 			]
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,12 @@ import AccountCommands = require('./commands/AccountCommands');
 import EnvironmentCommands = require('./commands/EnvironmentCommands');
 import PublicCommands = require('./commands/PublicCommands');
 import { telemetryReporter, sendTelemetry, startAppInsights } from './utils/telemetry';
+import { getMakecomappJson, getMakecomappRootDir } from './local-development/makecomappjson';
+import { AppComponentType, AppComponentTypes } from './types/app-component-type.types';
+import { deleteLocalComponent } from './local-development/delete-local-component';
+import { catchError } from './error-handling';
+import { Uri } from 'vscode';
+import { removeRecursively } from './local-development/helpers/fs';
 
 let client: vscodeLanguageclient.LanguageClient;
 
@@ -231,6 +237,52 @@ export async function activate(context: vscode.ExtensionContext) {
 			},
 		},
 	);
+
+	// Component deletion context menu.
+	vscode.commands.registerCommand(
+		'apps-sdk.local-dev.delete-local-component',
+		// Delete folder will trigger file watcher
+		catchError('Delete local component', removeRecursively),
+	);
+
+	function parseComponentPath(path: string) {
+		const regex = new RegExp(`.*?/(${AppComponentTypes.join('|')})s/([^/]+)$`);
+		const matchComponentPath = path.match(regex);
+
+		if (matchComponentPath) {
+			const [, componentType, componentName] = matchComponentPath;
+			return { componentType: componentType as AppComponentType, componentName };
+		}
+		return null;
+	}
+
+	async function onFileDeleted(uri: Uri) {
+		const foundComponentInPath = parseComponentPath(uri.path);
+
+		// Path is not related to component.
+		if (!foundComponentInPath) {
+			return;
+		}
+
+		const makecomappJson = await getMakecomappJson(uri);
+		// The path is a valid component but is not listed in the manifest, so no action will be executed.
+		if (!makecomappJson.components[foundComponentInPath.componentType][foundComponentInPath.componentName]) {
+			return;
+		}
+
+		// The path is valid existing component, proceed with its deletion.
+		const rootDir = getMakecomappRootDir(uri);
+		await deleteLocalComponent(
+			rootDir,
+			foundComponentInPath.componentType as AppComponentType,
+			foundComponentInPath.componentName,
+		);
+	}
+
+	// Observe file/folder deletion even from external file explorer.
+	const watcher = vscode.workspace.createFileSystemWatcher('**/*');
+	watcher.onDidDelete(onFileDeleted);
+	context.subscriptions.push(watcher);
 
 	/**
 	 * TELEMETRY & APP INSIGHTS START

--- a/src/local-development/align-components-mapping.ts
+++ b/src/local-development/align-components-mapping.ts
@@ -54,7 +54,7 @@ export async function alignComponentsMapping(
 		componentMetadata: AppComponentMetadata;
 	}[] = [];
 	/**
-	 * Deleted locally: Missing in `makecomappJson`, but existing in `remoteComponents` and 'mapping'.
+	 * Deleted locally: Missing in local filesystem, but existing in `remoteComponents` and existing in 'mapping' with 'localDeleted: true'.
 	 * Common meaning: Deleted locally, but still exists in the remote Make.
 	 */
 	const deletedLocally: {

--- a/src/local-development/align-components-mapping.ts
+++ b/src/local-development/align-components-mapping.ts
@@ -4,7 +4,7 @@ import {
 	AppComponentMetadataWithCodeFiles,
 	LocalAppOriginWithSecret,
 } from './types/makecomapp.types';
-import { addComponentIdMapping, getMakecomappJson } from './makecomappjson';
+import { addComponentIdMapping, getMakecomappJson, updateMakecomappJson } from './makecomappjson';
 import { askForSelectMappedComponent, specialAnswers } from './ask-mapped-component';
 import { createRemoteAppComponent } from './create-remote-component';
 import { ComponentIdMappingHelper } from './helpers/component-id-mapping-helper';
@@ -13,6 +13,7 @@ import { RemoteComponentsSummary } from './types/remote-components-summary.types
 import { AppComponentType } from '../types/app-component-type.types';
 import { entries } from '../utils/typed-object';
 import { progresDialogReport } from '../utils/vscode-progress-dialog';
+import { deleteOriginComponent } from './delete-origin-component';
 
 /**
  * Compares list of components from two sources. If some component is missing on one side,
@@ -52,6 +53,15 @@ export async function alignComponentsMapping(
 		componentName: string;
 		componentMetadata: AppComponentMetadata;
 	}[] = [];
+	/**
+	 * Deleted locally: Missing in `makecomappJson`, but existing in `remoteComponents` and 'mapping'.
+	 * Common meaning: Deleted locally, but still exists in the remote Make.
+	 */
+	const deletedLocally: {
+		componentType: AppComponentType;
+		componentName: string;
+		componentMetadata: AppComponentMetadata;
+	}[] = [];
 
 	// Fill `remoteOnly`
 	for (const [componentType, components] of entries(remoteComponentsSummary)) {
@@ -59,6 +69,16 @@ export async function alignComponentsMapping(
 			const isLocalComponentKnown = origin.idMapping?.[componentType]?.find(
 				(idMappingItem) => idMappingItem.remote === componentName,
 			);
+
+			// Component was deleted locally. Still need to remove from origin.
+			if (isLocalComponentKnown && isLocalComponentKnown.localDeleted) {
+				deletedLocally.push({
+					componentType,
+					componentName,
+					componentMetadata,
+				});
+			}
+
 			if (isLocalComponentKnown === undefined) {
 				remoteOnly.push({
 					componentType,
@@ -109,6 +129,18 @@ export async function alignComponentsMapping(
 		const remoteOnlyInSpecificComponentType = remoteOnly.filter(
 			(component) => component.componentType === componentType,
 		);
+		const deletedLocallyInSpecificComponentType = deletedLocally.filter(
+			(component) => component.componentType === componentType,
+		);
+
+		// Resolve locally deleted components
+		let deletedLocallyComponent;
+		while ((deletedLocallyComponent = deletedLocallyInSpecificComponentType.shift()!)) {
+			await deleteOriginComponent(origin, componentType, deletedLocallyComponent.componentName);
+			const mappingHelper = new ComponentIdMappingHelper(makecomappJson, origin);
+			mappingHelper.removeByRemoteName(componentType, deletedLocallyComponent.componentName);
+			await updateMakecomappJson(makecomappRootDir, makecomappJson);
+		}
 
 		// Resolve 'localOnly' found components
 		if (newLocalComponentResolution !== 'ignore') {

--- a/src/local-development/code-pull-deploy.ts
+++ b/src/local-development/code-pull-deploy.ts
@@ -216,12 +216,6 @@ export async function pullComponentCodes(
 
 	sendTelemetry('pull_component_codes', { appComponentType, remoteComponentName });
 
-	// Pulling when there are undeployed changes. Override them and align the state with the origin.
-	const makecomappJson = await getMakecomappJson(localAppRootdir);
-	const componentIdMappingHelper = new ComponentIdMappingHelper(makecomappJson, origin);
-	componentIdMappingHelper.filterMappingItems(item => !item?.localDeleted);
-	await updateMakecomappJson(localAppRootdir, makecomappJson);
-
 	// Download codes from API to local files
 	for (const [codeType, codeFilePath] of entries(componentMetadata.codeFiles)) {
 		if (codeFilePath === null) {

--- a/src/local-development/code-pull-deploy.ts
+++ b/src/local-development/code-pull-deploy.ts
@@ -14,8 +14,6 @@ import { requestMakeApi } from '../utils/request-api-make';
 import { entries } from '../utils/typed-object';
 import { version as ExtensionVersion } from '../Meta';
 import { sendTelemetry } from '../utils/telemetry';
-import { ComponentIdMappingHelper } from './helpers/component-id-mapping-helper';
-import { getMakecomappJson, updateMakecomappJson } from './makecomappjson';
 
 /**
  * Download code from the Make API and save it to the local destination

--- a/src/local-development/delete-local-component.ts
+++ b/src/local-development/delete-local-component.ts
@@ -1,0 +1,35 @@
+import { AppComponentType } from '../types/app-component-type.types';
+import { log } from '../output-channel';
+import { removeModuleFromGroups } from './groups-json';
+import vscode from 'vscode';
+import { getMakecomappJson, updateMakecomappJson } from './makecomappjson';
+import { ComponentIdMappingHelper } from './helpers/component-id-mapping-helper';
+
+export async function deleteLocalComponent(anyProjectPath: vscode.Uri, componentType: AppComponentType, localComponentName: string) {
+	log('info', `Deleting local ${componentType} '${localComponentName}'`);
+
+	// Remove module groups
+	if (componentType === 'module') {
+		// TODO need to remap localComponentName -> originName (but its hard due to origins)
+		await removeModuleFromGroups(anyProjectPath, localComponentName);
+	}
+
+	// TODO should we try to find references? Delete used connection, rpc etc?
+
+	// Load manifest
+	const makecomappJson = await getMakecomappJson(anyProjectPath);
+
+	// Remove component from manifest
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { [localComponentName]: _ignored, ...updatedComponents } = makecomappJson.components[componentType];
+	makecomappJson.components[componentType] = updatedComponents;
+
+	// Add localDeleted property to mapping
+	for (const origin of makecomappJson.origins) {
+		const mappingHelper = new ComponentIdMappingHelper(makecomappJson, origin);
+		mappingHelper.addLocalDeleted(componentType, localComponentName);
+	}
+
+	// Save manifest
+	await updateMakecomappJson(anyProjectPath, makecomappJson);
+}

--- a/src/local-development/delete-local-component.ts
+++ b/src/local-development/delete-local-component.ts
@@ -1,7 +1,7 @@
 import { AppComponentType } from '../types/app-component-type.types';
 import { log } from '../output-channel';
 import { removeModuleFromGroups } from './groups-json';
-import vscode from 'vscode';
+import * as vscode from 'vscode';
 import { getMakecomappJson, updateMakecomappJson } from './makecomappjson';
 import { ComponentIdMappingHelper } from './helpers/component-id-mapping-helper';
 

--- a/src/local-development/delete-origin-component.ts
+++ b/src/local-development/delete-origin-component.ts
@@ -1,0 +1,24 @@
+import { AppComponentType } from '../types/app-component-type.types';
+import { log } from '../output-channel';
+import { requestMakeApi } from '../utils/request-api-make';
+import { AxiosRequestConfig } from 'axios';
+import { version as ExtensionVersion } from '../Meta';
+import { LocalAppOriginWithSecret } from './types/makecomapp.types';
+import { getComponentApiUrl } from './helpers/api-url';
+
+export async function deleteOriginComponent(origin: LocalAppOriginWithSecret, componentType: AppComponentType, remoteComponentName: string) {
+	log('info', `Deleting origin ${componentType} '${remoteComponentName}'`);
+
+	const axiosConfig: AxiosRequestConfig = {
+		url: getComponentApiUrl({ componentType: componentType, remoteComponentName, origin }),
+		method: 'DELETE',
+		headers: {
+			Authorization: 'Token ' + origin.apikey,
+			'imt-vsce-localmode': 'true',
+			'imt-apps-sdk-version': ExtensionVersion,
+		},
+	};
+	log('info', `Deleted origin ${componentType} '${remoteComponentName}'`);
+
+	await requestMakeApi(axiosConfig);
+}

--- a/src/local-development/groups-json.ts
+++ b/src/local-development/groups-json.ts
@@ -9,6 +9,7 @@ const limitConcurrency = throat(1);
  * Default target group is `Other` if exists, else the last one.
  */
 export async function optionalAddModuleToDefaultGroup(anyProjectPath: vscode.Uri, newModuleID: string): Promise<void> {
+	// TODO remap newModuleID to originModuleName (now newModuleID is localModuleName)
 	const groupsCodeFilePath = (await getMakecomappJson(anyProjectPath)).generalCodeFiles.groups;
 	if (groupsCodeFilePath === null) {
 		// Do not do anything if the groups file is being ignored in project.
@@ -34,6 +35,33 @@ export async function optionalAddModuleToDefaultGroup(anyProjectPath: vscode.Uri
 				new TextEncoder().encode(JSON.stringify(groupsJson, null, 4)),
 			);
 		}
+	});
+}
+
+export async function removeModuleFromGroups(anyProjectPath: vscode.Uri, originModuleName: string): Promise<void> {
+	const groupsCodeFilePath = (await getMakecomappJson(anyProjectPath)).generalCodeFiles.groups;
+	if (groupsCodeFilePath === null) {
+		// Do not do anything if the groups file is being ignored in project.
+		return;
+	}
+	const makeappRootdir = getMakecomappRootDir(anyProjectPath);
+	const groupsCodeUri = vscode.Uri.joinPath(makeappRootdir, groupsCodeFilePath);
+
+	await limitConcurrency(async () => {
+		const groupsJson: GroupsJson = JSON.parse(
+			new TextDecoder().decode(await vscode.workspace.fs.readFile(groupsCodeUri)),
+		);
+
+		// Filter module from all groups.
+		groupsJson.forEach((item: GroupJsonItem) => {
+			item.modules = item.modules.filter(module => module !== originModuleName);
+		});
+
+		// Save changes
+		await vscode.workspace.fs.writeFile(
+			groupsCodeUri,
+			new TextEncoder().encode(JSON.stringify(groupsJson, null, 4)),
+		);
 	});
 }
 

--- a/src/local-development/helpers/component-id-mapping-helper.ts
+++ b/src/local-development/helpers/component-id-mapping-helper.ts
@@ -1,14 +1,15 @@
 import { getOriginObject } from './get-origin-object';
-import { LocalAppOrigin, MakecomappJson } from '../types/makecomapp.types';
-import { AppComponentType, AppGeneralType } from '../../types/app-component-type.types';
+import { ComponentIdMappingItem, LocalAppOrigin, MakecomappJson } from '../types/makecomapp.types';
+import { AppComponentType, AppComponentTypes, AppGeneralType } from '../../types/app-component-type.types';
 
 /**
  * Provides helping function to find remote component name from local ID and vice versa.
  */
 export class ComponentIdMappingHelper {
-	constructor(private makecomappJson: MakecomappJson, private origin: LocalAppOrigin) {}
+	constructor(private makecomappJson: MakecomappJson, private origin: LocalAppOrigin) {
+	}
 
-	getRemoteName(componentType: AppComponentType | AppGeneralType, localId: string): string | null | undefined {
+	getMappingByLocalName(componentType: AppComponentType | AppGeneralType, localId: string) {
 		if (componentType === 'app') {
 			// This is special case, where "Common", "Readme" (etc.) are considered as members of virtual "app" compoment type, which has single component with ID ``.
 			return '';
@@ -26,8 +27,16 @@ export class ComponentIdMappingHelper {
 		if (matchedMappings.length >= 2) {
 			throw new Error(`Not unique mapping found for local ID "${localId}"`);
 		}
+		return matchedMappings[0];
+	}
 
-		return matchedMappings[0].remote;
+	getRemoteName(componentType: AppComponentType | AppGeneralType, localId: string): string | null | undefined {
+		const mapping = this.getMappingByLocalName(componentType, localId);
+		if (!mapping) {
+			return mapping;
+		}
+
+		return mapping.remote;
 	}
 
 	getExistingRemoteName(componentType: AppComponentType | AppGeneralType, localId: string): string | null {
@@ -64,10 +73,7 @@ export class ComponentIdMappingHelper {
 		}
 	}
 
-	private getLocalId(
-		componentType: AppComponentType | AppGeneralType,
-		remoteName: string,
-	): string | null | undefined {
+	private getMappingByRemoteName(componentType: AppComponentType | AppGeneralType, remoteName: string) {
 		if (componentType === 'app') {
 			// This is special case, where "Common", "Readme" (etc.) are considered as members of virtual "app" compoment type, which has single component with ID ``.
 			return '';
@@ -86,7 +92,30 @@ export class ComponentIdMappingHelper {
 			throw new Error(`Not unique mapping found for remote name "${remoteName}"`);
 		}
 
-		return matchedMappings[0].local;
+		return matchedMappings[0];
+	}
+
+	/**
+	 * Retrieves the local ID associated with a given remote name for a specified component type.
+	 *
+	 * This function searches for a mapping entry based on the `componentType` and `remoteName`.
+	 * If a matching entry is found, it returns the `local` ID associated with that mapping.
+	 * If no matching mapping exists, it returns `null` or `undefined`.
+	 *
+	 * @private
+	 * @param {AppComponentType | AppGeneralType} componentType - The type of the component or general type to search within the mappings.
+	 * @param {string} remoteName - The name of the remote component to find the local ID for.
+	 * @returns {string | null | undefined} - The local ID if found, otherwise `null` or `undefined` if no mapping exists.
+	 */
+	private getLocalId(
+		componentType: AppComponentType | AppGeneralType,
+		remoteName: string,
+	): string | null | undefined {
+		const mapping = this.getMappingByRemoteName(componentType, remoteName);
+		if (!mapping) {
+			return mapping;
+		}
+		return mapping.local;
 	}
 
 	getExistingLocalId(componentType: AppComponentType | AppGeneralType, remoteName: string): string | null {
@@ -97,5 +126,42 @@ export class ComponentIdMappingHelper {
 		}
 
 		return localId;
+	}
+
+	addLocalDeleted(componentType: AppComponentType | AppGeneralType, localId: string) {
+		const mapping = this.getMappingByLocalName(componentType, localId);
+		if (!mapping) {
+			return;
+		}
+		mapping.localDeleted = true;
+	}
+
+	/**
+	 * Removes a mapping entry for a specified component type based on the remote component name.
+	 *
+	 * This function finds the specified component type within the `idMapping` of `makecomappJson`
+	 * for the given origin. If an entry with a matching remote component name exists,
+	 * it is filtered out from the mappings.
+	 *
+	 * @param {AppComponentType} componentType - The type of the component to target in the mapping.
+	 * @param {string} originComponentName - The name of the remote component to remove from the mapping.
+	 */
+	removeByRemoteName(componentType: AppComponentType, originComponentName: string) {
+		const originInMakecomappJson = getOriginObject(this.makecomappJson, this.origin);
+
+		if (originInMakecomappJson.idMapping?.[componentType]) {
+			originInMakecomappJson.idMapping[componentType] = originInMakecomappJson.idMapping[componentType].filter(mapping => mapping.remote !== originComponentName);
+		}
+	}
+
+
+	filterMappingItems(filterCondition: (it: ComponentIdMappingItem) => boolean) {
+		const originInMakecomappJson = getOriginObject(this.makecomappJson, this.origin);
+
+		for (const componentType of AppComponentTypes) {
+			if (originInMakecomappJson.idMapping?.[componentType]) {
+				originInMakecomappJson.idMapping[componentType] = originInMakecomappJson.idMapping[componentType].filter(filterCondition);
+			}
+		}
 	}
 }

--- a/src/local-development/helpers/component-id-mapping-helper.ts
+++ b/src/local-development/helpers/component-id-mapping-helper.ts
@@ -162,6 +162,10 @@ export class ComponentIdMappingHelper {
 	}
 
 
+	/**
+	 * Updates the `idMapping` mapping in `this.makecomappJson`:
+	 * Keeps the the only items that matches with defined `filterCondition`, all other items are removed.
+	 */
 	filterMappingItems(filterCondition: (it: ComponentIdMappingItem) => boolean) {
 		const originInMakecomappJson = getOriginObject(this.makecomappJson, this.origin);
 
@@ -174,8 +178,6 @@ export class ComponentIdMappingHelper {
 			if (this.origin.idMapping?.[componentType]) {
 				this.origin.idMapping[componentType] = this.origin.idMapping[componentType].filter(filterCondition);
 			}
-
 		}
-		return originInMakecomappJson;
 	}
 }

--- a/src/local-development/helpers/component-id-mapping-helper.ts
+++ b/src/local-development/helpers/component-id-mapping-helper.ts
@@ -149,9 +149,16 @@ export class ComponentIdMappingHelper {
 	removeByRemoteName(componentType: AppComponentType, originComponentName: string) {
 		const originInMakecomappJson = getOriginObject(this.makecomappJson, this.origin);
 
+		// Modify makecomapp object
 		if (originInMakecomappJson.idMapping?.[componentType]) {
 			originInMakecomappJson.idMapping[componentType] = originInMakecomappJson.idMapping[componentType].filter(mapping => mapping.remote !== originComponentName);
 		}
+		// Modify origin object that
+		if (this.origin.idMapping?.[componentType]) {
+			this.origin.idMapping[componentType] = this.origin.idMapping[componentType].filter(mapping => mapping.remote !== originComponentName);
+		}
+
+		return originInMakecomappJson;
 	}
 
 
@@ -159,9 +166,16 @@ export class ComponentIdMappingHelper {
 		const originInMakecomappJson = getOriginObject(this.makecomappJson, this.origin);
 
 		for (const componentType of AppComponentTypes) {
+			// Modify makecomapp object
 			if (originInMakecomappJson.idMapping?.[componentType]) {
 				originInMakecomappJson.idMapping[componentType] = originInMakecomappJson.idMapping[componentType].filter(filterCondition);
 			}
+			// Modify origin object that
+			if (this.origin.idMapping?.[componentType]) {
+				this.origin.idMapping[componentType] = this.origin.idMapping[componentType].filter(filterCondition);
+			}
+
 		}
+		return originInMakecomappJson;
 	}
 }

--- a/src/local-development/helpers/fs.ts
+++ b/src/local-development/helpers/fs.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { Uri } from 'vscode';
+
+export async function exists(uri: vscode.Uri): Promise<boolean> {
+	try {
+		await vscode.workspace.fs.stat(uri);
+		return true; // File exists
+	} catch (error) {
+		if (error instanceof vscode.FileSystemError && error.code === 'FileNotFound') {
+			return false; // File does not exist
+		}
+		// Handle other errors if necessary
+		throw error;
+	}
+}
+
+export async function removeRecursively(uri: Uri) {
+	await vscode.workspace.fs.delete(uri, { recursive: true });
+}

--- a/src/local-development/helpers/fs.ts
+++ b/src/local-development/helpers/fs.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { Uri } from 'vscode';
 
 export async function exists(uri: vscode.Uri): Promise<boolean> {
 	try {
@@ -12,8 +11,4 @@ export async function exists(uri: vscode.Uri): Promise<boolean> {
 		// Handle other errors if necessary
 		throw error;
 	}
-}
-
-export async function removeRecursively(uri: Uri) {
-	await vscode.workspace.fs.delete(uri, { recursive: true });
 }

--- a/src/local-development/makecomappjson.ts
+++ b/src/local-development/makecomappjson.ts
@@ -27,7 +27,7 @@ export function getMakecomappRootDir(anyProjectPath: vscode.Uri): vscode.Uri {
 		workspace.uri.path,
 		anyProjectPath.path,
 	)}" is not a part of a Make App.`;
-	// eslint-disable-next-line no-constant-condition
+
 	while (true) {
 		currentDirRelative = path.posix.relative(workspace.uri.path, currentProjectPath.path);
 		if (currentDirRelative.startsWith('..')) {
@@ -102,7 +102,7 @@ export async function getMakecomappJson(anyProjectPath: vscode.Uri): Promise<Mak
 /**
  * Writes new content into `makecomapp.json` file.
  */
-async function updateMakecomappJson(anyProjectPath: vscode.Uri, newMakecomappJson: MakecomappJson): Promise<void> {
+export async function updateMakecomappJson(anyProjectPath: vscode.Uri, newMakecomappJson: MakecomappJson): Promise<void> {
 	const makecomappRootdir = getMakecomappRootDir(anyProjectPath);
 	const makecomappJsonPath = vscode.Uri.joinPath(makecomappRootdir, MAKECOMAPP_FILENAME);
 	await vscode.workspace.fs.writeFile(

--- a/src/local-development/types/makecomapp.schema.json
+++ b/src/local-development/types/makecomapp.schema.json
@@ -103,6 +103,11 @@
                         "string"
                     ]
                 },
+                "localDeleted": {
+                    "description": "Note: True indicates that the component was deleted and must be aligned with the origin. Otherwise, the component is still relevant.",
+                    "title": "localDeleted",
+                    "type": "boolean"
+                },
                 "remote": {
                     "description": "Note: `null` means that the local component is not paired to remote. In consequences these local components will be ignored during pull or deploy.",
                     "title": "remote",

--- a/src/local-development/types/makecomapp.types.ts
+++ b/src/local-development/types/makecomapp.types.ts
@@ -34,11 +34,13 @@ export type AppComponentTypesMetadata<T> = Record<AppComponentType, AppComponent
  */
 type ComponentIdMapping = Record<AppComponentType, ComponentIdMappingItem[]>;
 
-interface ComponentIdMappingItem {
+export interface ComponentIdMappingItem {
 	/** Note: `null` means that the remote component is not paired to local. In consequences these remote components will be ignored during pull or deploy. */
 	local: string | null;
 	/** Note: `null` means that the local component is not paired to remote. In consequences these local components will be ignored during pull or deploy. */
 	remote: string | null;
+	/** Note: True indicates that the component was deleted locally and must be aligned with the origin.  */
+	localDeleted?: boolean;
 }
 
 /**

--- a/src/types/app-component-type.types.ts
+++ b/src/types/app-component-type.types.ts
@@ -1,5 +1,7 @@
 export type AppComponentType = 'connection' | 'webhook' | 'module' | 'rpc' | 'function';
 
+export const AppComponentTypes: AppComponentType[] = ['connection', 'webhook', 'module', 'rpc', 'function'];
+
 /**
  * It is pseudotype used in API endpoint for general codes like "base", "common", "content" (readme).
  */


### PR DESCRIPTION
Implements a right-click context menu and file watcher that automatically removes all associated dependencies when a component is deleted locally. This ensures a clean environment and prevents orphaned dependencies in the project structure.