### PR TITLE
feat: add support for banner theme into parameters.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Unreleased
+-----------
+
+- Added support for the theme property of the banner directive in the App Interface.
+
 2.2.1 [2024-11-05] (pre-release)
 ------------------
 

--- a/syntaxes/imljson/schemas/parameters.json
+++ b/syntaxes/imljson/schemas/parameters.json
@@ -512,6 +512,10 @@
 					"type": "boolean",
 					"description": "Show close button on banner"
 				},
+				"theme": {
+					"type": "string",
+					"description": "Banner badge theme ['light' OR 'dark']"
+				},
 				"badge": {
 					"type": "string",
 					"description": "Banner badge title"


### PR DESCRIPTION
Change log:

- Support was added for the theme property of the banner directive in the App Interface.

Internal ticket: https://make.atlassian.net/browse/CDM-12050