### PR TITLE
fix: failed to delete a camelcase named module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 -----------
 
 - Added support for the theme property of the banner directive in the App Interface.
+- Fixed an issue where deleting components with camelCase names was not functioning correctly.
 
 2.2.1 [2024-11-05] (pre-release)
 ------------------


### PR DESCRIPTION
Fixed an issue where components named in camelCase were not being deleted properly due to folders being created in kebab-case format. Adjusted the deletion logic to handle this mismatch correctly.