### PR TITLE
fix: key binding for local delete action not working on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -836,7 +836,7 @@
 				{
 					"command": "apps-sdk.local-dev.delete-local-component",
 					"group": "7_modification",
-					"when": "resourcePath =~ /^.*\\/(modules|connections|rpcs|webhooks|functions)\\/[^\\/]+$/ && resourceExtname == ''"
+					"when": "resourcePath =~ /^.*[\\\\/](modules|connections|rpcs|webhooks|functions)[\\\\/][^\\\\/]+$/ && resourceExtname == ''"
 				}
 			]
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,7 +250,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	function parseComponentPath(componentPath: string): { componentType: AppComponentType; componentName: string } | null {
 		// Parse path
-		const pathParts = componentPath.split(path.sep);
+		const pathParts = componentPath.split('/');
 
 		// Should contain componentType and componentName
 		if (pathParts.length < 2) {


### PR DESCRIPTION
CDM-12723
https://make.atlassian.net/browse/CDM-12723
key binding for local delete action not working on windows due to wrong path separator.