### PR TITLE
fix: key binding for deploy to work in directory tree panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -851,7 +851,7 @@
 				"command": "apps-sdk.local-dev.deploy",
 				"key": "ctrl+alt+u",
 				"mac": "cmd+alt+u",
-				"when": "editorTextFocus"
+				"when": "editorTextFocus || explorerViewletFocus"
 			}
 		],
 		"configuration": {


### PR DESCRIPTION
CDM-12724
https://make.atlassian.net/browse/CDM-12724
fix key binding for deploy to work in directory tree panel