### PR TITLE
fix: mappable and static parameters json schema validation issue for plain rpc string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Unreleased
+------------------
+- Fixed mappable and static parameters json schema validation for plain rpc string
+
 2.2.5 [2024-12-18]
 ------------------
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -40,19 +40,19 @@ suite('App online file edit validations', () => {
 			filename: 'parameters.imljson',
 			expectedLanguage: 'imljson',
 			problematicContent: '{"invalidProperty":"someValue"}',
-			expectedProblemMessage: 'Incorrect type. Expected "array".',
+			expectedProblemMessage: 'Incorrect type. Expected one of array, string.',
 		},
 		{
 			filename: 'expect.imljson',
 			expectedLanguage: 'imljson',
 			problematicContent: '{"invalidProperty":"someValue"}',
-			expectedProblemMessage: 'Incorrect type. Expected "array".',
+			expectedProblemMessage: 'Incorrect type. Expected one of array, string.',
 		},
 		{
 			filename: 'interface.imljson',
 			expectedLanguage: 'imljson',
 			problematicContent: '{"invalidProperty":"someValue"}',
-			expectedProblemMessage: 'Incorrect type. Expected "array".',
+			expectedProblemMessage: 'Incorrect type. Expected one of array, string.',
 		},
 		{
 			filename: 'common.imljson',

--- a/syntaxes/imljson/schemas/parameters.json
+++ b/syntaxes/imljson/schemas/parameters.json
@@ -600,7 +600,7 @@
 			}
 		}
 	},
-	"type": "array",
+	"type": ["array", "string"],
 	"items": {
 		"$ref": "#/definitions/parameter"
 	}


### PR DESCRIPTION
fix: mappable and static parameters json schema validation issue for plain rpc string

CDM-9321
https://make.atlassian.net/browse/CDM-9321
string is now enabled for parameters