### PR TITLE
fix: run IML function tests against draft code, not published code

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "apps-sdk",
 	"displayName": "Make Apps Editor",
 	"description": "Helps to create, develop, download and deploy apps of the Make no-code visual integration and automation platform.",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"icon": "resources/make.png",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "apps-sdk",
 	"displayName": "Make Apps Editor",
 	"description": "Helps to create, develop, download and deploy apps of the Make no-code visual integration and automation platform.",
-	"version": "2.5.1",
+	"version": "2.5.0",
 	"icon": "resources/make.png",
 	"repository": {
 		"type": "git",

--- a/src/commands/FunctionCommands.ts
+++ b/src/commands/FunctionCommands.ts
@@ -98,16 +98,23 @@ export class FunctionCommands {
 				}
 			}
 
-			// Get current test code
-			const test = await Core.rpGet(`${urn}/${functionName}/test`, _authorization)
+			// Get current test code and the list of all function names
+			const [test, functionListResponse] = await Promise.all([
+				Core.rpGet(`${urn}/${functionName}/test`, _authorization),
+				Core.rpGet(`${urn}`, _authorization, { cols: ['name'] }),
+			]);
 
-			// Get all custom IML functions (includes the tested one)
-			let userFunctions: CustomImlFunction[] = await Core.rpGet(`${urn}`, _authorization, { code: true, cols: ['name', 'code'] })
-			if (_environment.version === 2) {
-				userFunctions = (<any>userFunctions).appFunctions;
-			}
+			const functionList: { name: string }[] = _environment.version === 2
+				? (functionListResponse as any).appFunctions
+				: functionListResponse;
 
-			// Merge codes
+			// Fetch each function's draft code via its direct endpoint
+			const userFunctions: CustomImlFunction[] = await Promise.all(
+				functionList.map(async (fn): Promise<CustomImlFunction> => ({
+					name: fn.name,
+					code: await Core.rpGet(`${urn}/${fn.name}/code`, _authorization),
+				})),
+			);
 
 			await executeCustomFunctionTest(functionName, test, userFunctions, outputChannel, _timezone);
 


### PR DESCRIPTION
JIRA: https://make.atlassian.net/browse/IEN-14781
The function test runner was fetching all function code via the listing endpoint (/functions?code=true), which returns the published version. Now fetches each function's code via its direct endpoint (/functions/{name}/code) to get the latest draft, matching how test code is already fetched.

**Summary:**
- Bug: Running IML function tests (F6 / "Run IML test") on a published app used the published (compiled) function code instead of the latest draft. Edits to code.js were not reflected when running tests until the app was re-published.
- Root cause: The test runner fetched function code via the listing endpoint (GET /functions?code=true), which returns the published code property. The test code was correctly fetched via its direct endpoint.
- Fix: Fetch each function's code individually via GET /functions/{name}/code (the direct draft endpoint), matching how test code is already fetched.

Test plan:
- [ ] Open an already-published app with custom IML functions

- [ ] Edit a function's code.js (e.g. change the return value)

- [ ] Save the change (sends it to server as draft)

- [ ] Run "Run IML test" (F6) — verify the test runs against the updated code, not the old published version

- [ ] Verify tests still pass for unpublished (new) apps as before

Made-with: Cursor AI Opus 4.6