### PR TITLE
feat: add data, statusCode, headers to error directive JSON schema

### DIFF
--- a/syntaxes/imljson/schemas/response.json
+++ b/syntaxes/imljson/schemas/response.json
@@ -68,6 +68,16 @@
 						"type": {
 							"description": "An expression that specifies the error type.",
 							"$ref": "enums.json#/definitions/error-type"
+						},
+						"data": {
+							"description": "Custom data to pass through the error handling path."
+						},
+						"statusCode": {
+							"description": "HTTP status code or custom status code.",
+							"type": ["number", "string"]
+						},
+						"headers": {
+							"description": "Response headers to pass through the error handling path."
 						}
 					},
 					"patternProperties": {
@@ -83,6 +93,16 @@
 								"type": {
 									"description": "An expression that specifies the error type.",
 									"$ref": "enums.json#/definitions/error-type"
+								},
+								"data": {
+									"description": "Custom data to pass through the error handling path."
+								},
+								"statusCode": {
+									"description": "HTTP status code or custom status code.",
+									"type": ["number", "string"]
+								},
+								"headers": {
+									"description": "Response headers to pass through the error handling path."
 								}
 							},
 							"required": ["message"],


### PR DESCRIPTION
## IEN-15364

https://make.atlassian.net/browse/IEN-15364

## Description

Updates the Monaco JSON schema (`response.json`) to allow `data`, `statusCode`, and `headers` properties in the `#error` directive — both at the top level and within status-code-specific overrides (`^[0-9]{3}$`). Mirrors the same schema change applied to `imt-web-zone`. Resolves "Property is not allowed" validation errors in the VS Code extension for these new fields.

## Diamond

https://make.atlassian.net/wiki/spaces/RD/database/3064659981?contentId=3064659981&entryId=9fc99097-088a-4a5d-ac80-3f1ba12a5545&savedViewId=bb67ecdc-219a-4e3b-a753-8d9fc32be6b3