### PR TITLE
feat: add delay property to pagination JSON schema

### DIFF
--- a/syntaxes/imljson/schemas/sources.json
+++ b/syntaxes/imljson/schemas/sources.json
@@ -286,6 +286,10 @@
 				"condition": {
 					"description": "This directive specifies whether to execute the pagination request or not.",
 					"type": ["boolean", "string"]
+				},
+				"delay": {
+					"description": "Delay in milliseconds between paginated requests. Clamped to 0-30000.",
+					"type": ["number", "string"]
 				}
 			}
 		},


### PR DESCRIPTION
## IEN-15365

https://make.atlassian.net/browse/IEN-15365

## Description

Adds the `delay` property (`type: ["number", "string"]`) to the `#pagination` definition in the Monaco JSON schema (`sources.json`). Mirrors the same schema change applied to `imt-web-zone`. Resolves "Property is not allowed" validation error in the VS Code extension for `pagination.delay`, which was added in IEN-14780 but the schema was never updated.

## Diamond

https://make.atlassian.net/browse/IEN-14780