### PR TITLE
feat: add search field to filter custom apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,18 @@
 		],
 		"commands": [
 			{
+				"command": "apps-sdk.search",
+				"title": "Search Apps",
+				"category": "Make Apps",
+				"icon": "$(search)"
+			},
+			{
+				"command": "apps-sdk.search.clear",
+				"title": "Clear Search",
+				"category": "Make Apps",
+				"icon": "$(close)"
+			},
+			{
 				"command": "apps-sdk.refresh",
 				"title": "Refresh",
 				"category": "Make Apps",
@@ -495,19 +507,29 @@
 			],
 			"view/title": [
 				{
+					"command": "apps-sdk.search",
+					"when": "view == apps && config.apps-sdk.login == true && !apps-sdk.searchActive",
+					"group": "navigation@1"
+				},
+				{
+					"command": "apps-sdk.search.clear",
+					"when": "view == apps && config.apps-sdk.login == true && apps-sdk.searchActive",
+					"group": "navigation@1"
+				},
+				{
 					"command": "apps-sdk.refresh",
 					"when": "view == apps && config.apps-sdk.login == true",
-					"group": "navigation"
+					"group": "navigation@2"
 				},
 				{
 					"command": "apps-sdk.app.new",
 					"when": "view == apps && config.apps-sdk.login == true",
-					"group": "navigation"
+					"group": "navigation@3"
 				},
 				{
 					"command": "apps-sdk.app.import",
 					"when": "view == apps && config.apps-sdk.login == true",
-					"group": "navigation"
+					"group": "navigation@4"
 				}
 			],
 			"view/item/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,7 +196,30 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 
 	const appsProvider = new AppsProvider(_authorization, _environment, sourceCodeLocalTempBasedir, _admin);
-	vscode.window.registerTreeDataProvider('apps', appsProvider);
+	const appsTreeView = vscode.window.createTreeView('apps', { treeDataProvider: appsProvider });
+
+	function updateSearchContext() {
+		const isActive = appsProvider.searchFilter.length > 0;
+		vscode.commands.executeCommand('setContext', 'apps-sdk.searchActive', isActive);
+		appsTreeView.description = isActive ? `Filter: "${appsProvider.searchFilter}"` : undefined;
+	}
+
+	vscode.commands.registerCommand('apps-sdk.search', async () => {
+		const term = await vscode.window.showInputBox({
+			prompt: 'Search custom apps by name, label, or description',
+			placeHolder: 'Type to filter apps…',
+			value: appsProvider.searchFilter,
+		});
+		if (term !== undefined) {
+			appsProvider.setSearchFilter(term);
+			updateSearchContext();
+		}
+	});
+
+	vscode.commands.registerCommand('apps-sdk.search.clear', () => {
+		appsProvider.clearSearchFilter();
+		updateSearchContext();
+	});
 
 	/**
 	 * Registering commands

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,7 +204,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		appsTreeView.description = isActive ? `Filter: "${appsProvider.searchFilter}"` : undefined;
 	}
 
-	vscode.commands.registerCommand('apps-sdk.search', async () => {
+	vscode.commands.registerCommand('apps-sdk.search', catchError('Search custom apps', async () => {
 		const term = await vscode.window.showInputBox({
 			prompt: 'Search custom apps by name, label, or description',
 			placeHolder: 'Type to filter apps…',
@@ -214,12 +214,12 @@ export async function activate(context: vscode.ExtensionContext) {
 			appsProvider.setSearchFilter(term);
 			updateSearchContext();
 		}
-	});
+	}));
 
-	vscode.commands.registerCommand('apps-sdk.search.clear', () => {
+	vscode.commands.registerCommand('apps-sdk.search.clear', catchError('Clear custom apps search', async () => {
 		appsProvider.clearSearchFilter();
 		updateSearchContext();
-	});
+	}));
 
 	/**
 	 * Registering commands

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -17,6 +17,21 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		this._baseUrl = _environment.baseUrl;
 		this._DIR = _DIR
 		this._admin = _admin;
+		this._searchFilter = '';
+	}
+
+	get searchFilter() {
+		return this._searchFilter;
+	}
+
+	setSearchFilter(term) {
+		this._searchFilter = (term || '').trim();
+		this.refresh();
+	}
+
+	clearSearchFilter() {
+		this._searchFilter = '';
+		this.refresh();
 	}
 
 	refresh() {
@@ -54,11 +69,21 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			if (response === undefined) { return }
 			//#endregion Get apps list
 
-			const apps = await Promise.all(response.map(async (app) => {
+			let apps = await Promise.all(response.map(async (app) => {
 				const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, false);
 				return new App(app.name, app.label, app.description, app.version, app.public, app.approved, app.theme, app.changes, iconVersion)
 			}));
 			apps.sort(Core.compareApps)
+
+			if (this._searchFilter) {
+				const needle = this._searchFilter.toLowerCase();
+				apps = apps.filter(app =>
+					app.bareLabel.toLowerCase().includes(needle) ||
+					app.name.toLowerCase().includes(needle) ||
+					(app.description && app.description.toLowerCase().includes(needle))
+				);
+			}
+
 			return apps
 		}
 		/*

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -26,16 +26,38 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 
 	setSearchFilter(term) {
 		this._searchFilter = (term || '').trim();
-		this.refresh();
+		// Only re-render the tree to apply the filter. Intentionally NOT calling refresh():
+		// a full refresh reloads everything and (with background icon loading) invalidates the icon cache,
+		// which would re-download all icons on every search change.
+		this._onDidChangeTreeData.fire();
 	}
 
 	clearSearchFilter() {
 		this._searchFilter = '';
-		this.refresh();
+		// See note in setSearchFilter: re-render only, do not invalidate caches.
+		this._onDidChangeTreeData.fire();
 	}
 
 	refresh() {
 		this._onDidChangeTreeData.fire();
+	}
+
+	/**
+	 * Filters the given apps by the active search term, matching (case-insensitive)
+	 * against the app's label, name (id), or description.
+	 * @param {Array} apps Apps to filter.
+	 * @returns {Array} The matching apps, or all apps when no filter is active.
+	 */
+	_applySearchFilter(apps) {
+		if (!this._searchFilter) {
+			return apps;
+		}
+		const needle = this._searchFilter.toLowerCase();
+		return apps.filter(app =>
+			app.bareLabel.toLowerCase().includes(needle) ||
+			app.name.toLowerCase().includes(needle) ||
+			(app.description && app.description.toLowerCase().includes(needle))
+		);
 	}
 
 	getParent(element /* : Dependency */) {
@@ -75,14 +97,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			}));
 			apps.sort(Core.compareApps)
 
-			if (this._searchFilter) {
-				const needle = this._searchFilter.toLowerCase();
-				apps = apps.filter(app =>
-					app.bareLabel.toLowerCase().includes(needle) ||
-					app.name.toLowerCase().includes(needle) ||
-					(app.description && app.description.toLowerCase().includes(needle))
-				);
-			}
+			apps = this._applySearchFilter(apps)
 
 			return apps
 		}

--- a/src/providers/AppsProvider.test.ts
+++ b/src/providers/AppsProvider.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { AppsProvider } from './AppsProvider';
+import App from '../tree/App';
 
 /**
  * Unit coverage for the search-filter state on the Custom apps tree provider.
@@ -63,5 +64,53 @@ suite('AppsProvider search filter', () => {
 		provider.clearSearchFilter();
 		subscription.dispose();
 		assert.strictEqual(fireCount, 1);
+	});
+});
+
+/**
+ * Unit coverage for the actual app-filtering logic (`_applySearchFilter`),
+ * matching against label, name (id), and description case-insensitively.
+ */
+suite('AppsProvider _applySearchFilter()', () => {
+	const environment = { baseUrl: 'https://example.com', version: 2 } as any;
+
+	// Real App instances so the test also guards the App shape (bareLabel/name/description)
+	// that the filter depends on. Note: App defaults a missing description to '' (see src/tree/App.js).
+	const apps = [
+		new (App as any)('createContact', 'Create a Contact', 'Creates a new contact', 1, false, false, 'light', [], 0),
+		new (App as any)('rmRecord', 'Delete a Record', 'Removes an existing record', 1, false, false, 'light', [], 0),
+		new (App as any)('listUsers', 'List Users', undefined, 1, false, false, 'light', [], 0),
+	];
+
+	function filterWith(term: string) {
+		const provider = new (AppsProvider as any)('Token abc', environment, '/tmp/apps-sdk-test', false);
+		provider.setSearchFilter(term);
+		return provider._applySearchFilter(apps).map((app: { name: string }) => app.name);
+	}
+
+	test('Returns all apps when no filter is active', () => {
+		const provider = new (AppsProvider as any)('Token abc', environment, '/tmp/apps-sdk-test', false);
+		assert.deepStrictEqual(provider._applySearchFilter(apps), apps);
+	});
+
+	test('Matches by label (case-insensitive)', () => {
+		assert.deepStrictEqual(filterWith('contact'), ['createContact']);
+	});
+
+	test('Matches by name when it differs from the label', () => {
+		assert.deepStrictEqual(filterWith('rmrecord'), ['rmRecord']);
+	});
+
+	test('Matches by description', () => {
+		assert.deepStrictEqual(filterWith('removes'), ['rmRecord']);
+	});
+
+	test('Handles an empty (defaulted) description, matching via other fields', () => {
+		assert.strictEqual(apps[2].description, '', 'App defaults a missing description to an empty string');
+		assert.deepStrictEqual(filterWith('users'), ['listUsers']);
+	});
+
+	test('Returns an empty array when nothing matches', () => {
+		assert.deepStrictEqual(filterWith('nonexistent'), []);
 	});
 });

--- a/src/providers/AppsProvider.test.ts
+++ b/src/providers/AppsProvider.test.ts
@@ -1,0 +1,67 @@
+import * as assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { AppsProvider } from './AppsProvider';
+
+/**
+ * Unit coverage for the search-filter state on the Custom apps tree provider.
+ * Verifies the filter getter/setter/clear behavior and that mutating the filter
+ * triggers a tree refresh (`onDidChangeTreeData`), preventing regressions in the
+ * search feature without requiring a live Make environment.
+ */
+suite('AppsProvider search filter', () => {
+	const environment = { baseUrl: 'https://example.com', version: 2 } as any;
+
+	function createProvider() {
+		return new (AppsProvider as any)('Token abc', environment, '/tmp/apps-sdk-test', false);
+	}
+
+	test('Defaults to an empty filter', () => {
+		const provider = createProvider();
+		assert.strictEqual(provider.searchFilter, '');
+	});
+
+	test('setSearchFilter stores the trimmed term', () => {
+		const provider = createProvider();
+		provider.setSearchFilter('  Hello World  ');
+		assert.strictEqual(provider.searchFilter, 'Hello World');
+	});
+
+	test('setSearchFilter coerces nullish input to an empty string', () => {
+		const provider = createProvider();
+		provider.setSearchFilter(undefined);
+		assert.strictEqual(provider.searchFilter, '', 'undefined becomes empty string');
+		provider.setSearchFilter('term');
+		provider.setSearchFilter(null);
+		assert.strictEqual(provider.searchFilter, '', 'null becomes empty string');
+	});
+
+	test('clearSearchFilter resets the filter to an empty string', () => {
+		const provider = createProvider();
+		provider.setSearchFilter('something');
+		provider.clearSearchFilter();
+		assert.strictEqual(provider.searchFilter, '');
+	});
+
+	test('setSearchFilter fires a tree refresh', () => {
+		const provider = createProvider();
+		let fireCount = 0;
+		const subscription = provider.onDidChangeTreeData(() => {
+			fireCount += 1;
+		});
+		provider.setSearchFilter('abc');
+		subscription.dispose();
+		assert.strictEqual(fireCount, 1);
+	});
+
+	test('clearSearchFilter fires a tree refresh', () => {
+		const provider = createProvider();
+		provider.setSearchFilter('abc');
+		let fireCount = 0;
+		const subscription = provider.onDidChangeTreeData(() => {
+			fireCount += 1;
+		});
+		provider.clearSearchFilter();
+		subscription.dispose();
+		assert.strictEqual(fireCount, 1);
+	});
+});


### PR DESCRIPTION
https://make.atlassian.net/browse/IEN-15703

## Summary
- Adds a **Search** action to the Custom apps view title bar that filters apps by name, label, or description.
- Adds a **Clear search** toggle that appears while a filter is active, plus an active-filter indicator in the view description.
- Switches the apps tree registration to `createTreeView` so the active filter term can be shown.

## Changes
- `package.json` - new `apps-sdk.search` and `apps-sdk.search.clear` commands + view/title menu entries (toggled via the `apps-sdk.searchActive` context key).
- `src/extension.ts` - `createTreeView` + search/clear command handlers and context/description updates.
- `src/providers/AppsProvider.js` - search filter state and client-side filtering at the apps level.

## Test plan
- [ ] Open the Custom apps view; click the search icon and type a term -> only matching apps remain.
- [ ] Verify the clear (x) icon appears while filtering and resets the list.
- [ ] Verify the view description shows the active filter term.
