### PR TITLE
feat: lazy background loading of app icons

### DIFF
--- a/src/commands/AppCommands.js
+++ b/src/commands/AppCommands.js
@@ -484,12 +484,18 @@ class AppCommands {
 						data: fs.createReadStream(uri[0].fsPath),
 					});
 
-					// If everything has gone well, close the webview panel and refresh the tree (the new icon will be loaded)
-					if (await asyncfile.exists(rawIcon.dark)) {
-						await asyncfile.rename(rawIcon.dark, `${rawIcon.dark}.old`);
-					}
-					if (await asyncfile.exists(rawIcon.light)) {
-						await asyncfile.rename(rawIcon.light, `${rawIcon.light}.old`);
+					// If everything has gone well, close the webview panel and refresh the tree (the new icon will be loaded).
+					// Invalidate every locally cached icon path so the background loader re-downloads the fresh one:
+					//  - `rawIcon.*`: the just-resolved path (may not exist if the on-demand fetch failed and version stayed 0)
+					//  - `app.rawIcon.*`: the tree node's current cached path (e.g. from an earlier session/background load)
+					const stalePaths = new Set([
+						rawIcon.dark, rawIcon.light,
+						app.rawIcon?.dark, app.rawIcon?.light,
+					].filter(Boolean));
+					for (const stalePath of stalePaths) {
+						if (await asyncfile.exists(stalePath)) {
+							await asyncfile.rename(stalePath, `${stalePath}.old`);
+						}
 					}
 
 					vscode.commands.executeCommand('apps-sdk.refresh');

--- a/src/commands/AppCommands.js
+++ b/src/commands/AppCommands.js
@@ -408,6 +408,10 @@ class AppCommands {
 				}
 			);
 
+			// Track disposal so we never touch the webview after the user closes the panel (that throws).
+			let panelDisposed = false;
+			panel.onDidDispose(() => { panelDisposed = true; });
+
 			// Show a loading indicator while the current icon is fetched on demand.
 			panel.webview.html = getIconLoadingHtml();
 
@@ -422,6 +426,12 @@ class AppCommands {
 				);
 			} catch (err) {
 				showError(err, 'Get/change icon');
+			}
+
+			// If the user closed the panel while the icon was downloading, stop here -
+			// writing to a disposed webview (or registering its listeners) would throw.
+			if (panelDisposed) {
+				return;
 			}
 
 			// Resolve the local path of the freshly downloaded icon (version may differ from the tree node).

--- a/src/commands/AppCommands.js
+++ b/src/commands/AppCommands.js
@@ -22,6 +22,29 @@ const AdmZip = require('adm-zip');
 const { showError, catchError } = require('../error-handling');
 const { promisify2 } = require('../utils');
 const { getModuleDefFromId, getModuleDefFromType } = require('../services/module-types-naming');
+const { downloadAndStoreAppIcon, getIconLocalPath } = require('../libs/app-icon');
+
+/**
+ * Returns a self-contained HTML page with a centered spinner, shown in the icon webview
+ * while the app icon is being fetched on demand.
+ */
+function getIconLoadingHtml() {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<style>
+		body { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; margin: 0; font-family: var(--vscode-font-family); color: var(--vscode-foreground); }
+		.spinner { width: 40px; height: 40px; border: 4px solid var(--vscode-foreground); border-top-color: transparent; border-radius: 50%; animation: spin 1s linear infinite; margin-bottom: 16px; opacity: 0.8; }
+		@keyframes spin { to { transform: rotate(360deg); } }
+	</style>
+</head>
+<body>
+	<div class="spinner"></div>
+	<div>Loading app icon…</div>
+</body>
+</html>`;
+}
 
 class AppCommands {
 	static async register(appsProvider, _authorization, _environment, _admin) {
@@ -385,19 +408,38 @@ class AppCommands {
 				}
 			);
 
+			// Show a loading indicator while the current icon is fetched on demand.
+			panel.webview.html = getIconLoadingHtml();
+
+			// Fetch this app's current icon on demand (do not wait for the background icon loader),
+			// forcing a fresh download so the user always edits the up-to-date icon.
+			// On failure, fall back to a blank icon so the user can still upload a new one.
+			let iconVersion = 0;
+			try {
+				iconVersion = await vscode.window.withProgress(
+					{ location: vscode.ProgressLocation.Notification, title: `Loading icon of ${app.label}…` },
+					() => downloadAndStoreAppIcon(app, _environment.baseUrl, _authorization, _environment, false, true)
+				);
+			} catch (err) {
+				showError(err, 'Get/change icon');
+			}
+
+			// Resolve the local path of the freshly downloaded icon (version may differ from the tree node).
+			const rawIcon = getIconLocalPath(app.name, app.version, iconVersion, false);
+
 			// Prepare variable for storing the base64
 			let buff;
 
 			// If the icon exists on the disc -> get its BASE64
-			if (fs.existsSync(app.rawIcon.dark)) {
-				buff = Buffer.from(fs.readFileSync(app.rawIcon.dark)).toString('base64');
+			if (iconVersion > 0 && fs.existsSync(rawIcon.dark)) {
+				buff = Buffer.from(fs.readFileSync(rawIcon.dark)).toString('base64');
 			} else {
 				// If not, use the BASE64 of blank 512*512 png square
 				// eslint-disable-next-line max-len
 				buff = 'iVBORw0KGgoAAAANSUhEUgAAAgAAAAIAAQMAAADOtka5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAADZJREFUeJztwQEBAAAAgiD/r25IQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfBuCAAAB0niJ8AAAAABJRU5ErkJggg==';
 			}
 
-			// Inject the theme color and the icon to the generated HTML
+			// Inject the theme color and the icon to the generated HTML (replaces the loading spinner).
 			panel.webview.html = Core.getIconHtml(buff, app.theme, path.join(__dirname, '..', '..'));
 
 			panel.webview.onDidReceiveMessage(catchError('Icon change', async (message) => {
@@ -443,11 +485,11 @@ class AppCommands {
 					});
 
 					// If everything has gone well, close the webview panel and refresh the tree (the new icon will be loaded)
-					if (await asyncfile.exists(app.rawIcon.dark)) {
-						await asyncfile.rename(app.rawIcon.dark, `${app.rawIcon.dark}.old`);
+					if (await asyncfile.exists(rawIcon.dark)) {
+						await asyncfile.rename(rawIcon.dark, `${rawIcon.dark}.old`);
 					}
-					if (await asyncfile.exists(app.rawIcon.light)) {
-						await asyncfile.rename(app.rawIcon.light, `${app.rawIcon.light}.old`);
+					if (await asyncfile.exists(rawIcon.light)) {
+						await asyncfile.rename(rawIcon.light, `${rawIcon.light}.old`);
 					}
 
 					vscode.commands.executeCommand('apps-sdk.refresh');

--- a/src/libs/app-icon.ts
+++ b/src/libs/app-icon.ts
@@ -19,6 +19,7 @@ export async function downloadAndStoreAppIcon(
 	apiAuthorization: string,
 	environment: Environment,
 	_isAppOpensource: boolean,
+	forceRedownload = false,
 ): Promise<number> {
 	try {
 		let iconVersion = 0; // TODO Investigate usage of iconVersion. Remove if not needed.
@@ -28,7 +29,7 @@ export async function downloadAndStoreAppIcon(
 			iconLocalPath = getIconLocalPath(app.name, app.version, iconVersion, false);
 		} while (existsSync(`${iconLocalPath.dark}.old`)); // TODO Investigate the usage of `.old` files. Remove if not needed.
 
-		if (!existsSync(iconLocalPath.dark)) {
+		if (forceRedownload || !existsSync(iconLocalPath.dark)) {
 			// Download new icon from API to localdir
 			// TODO Do not wait for icon download. Load the tree without icons and download on the background.
 			try {

--- a/src/libs/background-icon-loader.ts
+++ b/src/libs/background-icon-loader.ts
@@ -1,0 +1,101 @@
+import { downloadAndStoreAppIcon } from './app-icon';
+import { log } from '../output-channel';
+import type { Environment } from '../types/environment.types';
+
+interface BackgroundIconLoaderOptions {
+	baseUrl: string;
+	authorization: string;
+	environment: Environment;
+	/** Passed as the `isAppOpensource` flag to `downloadAndStoreAppIcon`. */
+	isOpensource: boolean;
+	/** Prefix for error logs, e.g. "Background app" or "Background example". */
+	logLabel: string;
+	/** Called once after a run finishes caching icons, so the tree can re-render. */
+	onLoaded: () => void;
+}
+
+/**
+ * Loads app icons in the background and caches their versions. Shared by the
+ * Custom apps and Examples tree providers to avoid duplicating this logic.
+ *
+ * Guarantees:
+ *  - Single-flight: only one run executes at a time.
+ *  - Cancellable: `reset()` bumps a token so stale runs stop and cannot overwrite
+ *    the cache or fire a stale refresh.
+ *  - Resilient: a single icon failure is logged and skipped, never aborting the batch.
+ */
+export class BackgroundIconLoader {
+	private readonly options: BackgroundIconLoaderOptions;
+	private readonly iconVersions = new Map<string, number>();
+	private loaded = false;
+	private loading = false;
+	private token = 0;
+
+	constructor(options: BackgroundIconLoaderOptions) {
+		this.options = options;
+	}
+
+	/** Whether a run has completed and cached all icon versions. */
+	get isLoaded(): boolean {
+		return this.loaded;
+	}
+
+	/** Resolved icon version for an app (0 = not yet cached / no icon). */
+	getIconVersion(name: string, version: number): number {
+		return this.iconVersions.get(`${name}@${version}`) ?? 0;
+	}
+
+	/** Cancel any in-flight run and clear cached versions so icons are reloaded. */
+	reset(): void {
+		this.token++;
+		this.loading = false;
+		this.loaded = false;
+		this.iconVersions.clear();
+	}
+
+	/** Start a background run. No-op if a run is already in flight (single-flight). */
+	start(appsData: { name: string; version: number }[]): void {
+		if (this.loading) {
+			return;
+		}
+		this.loading = true;
+		const token = ++this.token;
+		setImmediate(async () => {
+			try {
+				for (const app of appsData) {
+					// Bail out if this run was superseded (reset or a newer run).
+					if (token !== this.token) {
+						return;
+					}
+					try {
+						const iconVersion = await downloadAndStoreAppIcon(
+							app as any,
+							this.options.baseUrl,
+							this.options.authorization,
+							this.options.environment,
+							this.options.isOpensource,
+						);
+						if (token !== this.token) {
+							return;
+						}
+						this.iconVersions.set(`${app.name}@${app.version}`, iconVersion);
+					} catch (err: any) {
+						// Isolate per-app failures (e.g. a corrupt PNG) so one bad icon does not abort the batch.
+						log('error', `${this.options.logLabel} icon load failed for ${app.name}@${app.version}: ${err.message}`);
+					}
+				}
+				if (token === this.token) {
+					this.loaded = true;
+					this.options.onLoaded();
+				}
+			} catch (err: any) {
+				log('error', `${this.options.logLabel} icon load failed: ${err.message}`);
+			} finally {
+				// Release the single-flight lock only if we still own the current run.
+				if (token === this.token) {
+					this.loading = false;
+				}
+			}
+		});
+	}
+}

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -6,8 +6,7 @@ const Item = require('../tree/Item')
 const Code = require('../tree/Code')
 const Core = require('../Core');
 const camelCase = require('lodash/camelCase');
-const { downloadAndStoreAppIcon } = require('../libs/app-icon');
-const { log } = require('../output-channel');
+const { BackgroundIconLoader } = require('../libs/background-icon-loader');
 
 class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 	constructor(_authorization, _environment, _DIR, _admin) {
@@ -18,56 +17,20 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		this._baseUrl = _environment.baseUrl;
 		this._DIR = _DIR
 		this._admin = _admin;
-		/** Resolved icon versions, keyed by `${name}@${version}`. */
-		this._iconVersions = new Map();
-		this._iconsLoaded = false;
-		/** True while a background icon load is in flight (single-flight guard). */
-		this._iconsLoading = false;
-		/** Monotonic token identifying the current icon-load run. Bumping it cancels older runs. */
-		this._iconLoadToken = 0;
+		this._iconLoader = new BackgroundIconLoader({
+			baseUrl: this._baseUrl,
+			authorization: this._authorization,
+			environment: this._environment,
+			isOpensource: false,
+			logLabel: 'Background app',
+			onLoaded: () => this._onDidChangeTreeData.fire(),
+		});
 	}
 
 	refresh() {
-		// Invalidate any in-flight background load and reset state so icons are reloaded.
-		this._iconLoadToken++;
-		this._iconsLoading = false;
-		this._iconsLoaded = false;
-		this._iconVersions.clear();
+		// Invalidate any in-flight background icon load and reset state so icons are reloaded.
+		this._iconLoader.reset();
 		this._onDidChangeTreeData.fire();
-	}
-
-	_startBackgroundIconLoad(appsData) {
-		// Single-flight: never run two background loaders at once.
-		if (this._iconsLoading) return;
-		this._iconsLoading = true;
-		const token = ++this._iconLoadToken;
-		setImmediate(async () => {
-			try {
-				for (const app of appsData) {
-					// Bail out if this run was superseded (refresh or a newer run).
-					if (token !== this._iconLoadToken) return;
-					try {
-						const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, false);
-						if (token !== this._iconLoadToken) return;
-						this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
-					} catch (err) {
-						// Isolate per-app failures (e.g. a corrupt PNG) so one bad icon does not abort the whole batch.
-						log('error', `Background app icon load failed for ${app.name}@${app.version}: ${err.message}`);
-					}
-				}
-				if (token === this._iconLoadToken) {
-					this._iconsLoaded = true;
-					this._onDidChangeTreeData.fire();
-				}
-			} catch (err) {
-				log('error', `Background app icon load failed: ${err.message}`);
-			} finally {
-				// Release the single-flight lock only if we still own the current run.
-				if (token === this._iconLoadToken) {
-					this._iconsLoading = false;
-				}
-			}
-		});
 	}
 
 	getParent(element /* : Dependency */) {
@@ -102,13 +65,13 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			//#endregion Get apps list
 
 			const apps = response.map((app) => {
-				const iconVersion = this._iconVersions.get(`${app.name}@${app.version}`) ?? 0;
+				const iconVersion = this._iconLoader.getIconVersion(app.name, app.version);
 				return new App(app.name, app.label, app.description, app.version, app.public, app.approved, app.theme, app.changes, iconVersion)
 			});
 			apps.sort(Core.compareApps)
 
-			if (!this._iconsLoaded) {
-				this._startBackgroundIconLoad(response);
+			if (!this._iconLoader.isLoaded) {
+				this._iconLoader.start(response);
 			}
 
 			return apps

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -7,6 +7,7 @@ const Code = require('../tree/Code')
 const Core = require('../Core');
 const camelCase = require('lodash/camelCase');
 const { downloadAndStoreAppIcon } = require('../libs/app-icon');
+const { log } = require('../output-channel');
 
 class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 	constructor(_authorization, _environment, _DIR, _admin) {
@@ -17,10 +18,36 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		this._baseUrl = _environment.baseUrl;
 		this._DIR = _DIR
 		this._admin = _admin;
+		/** Resolved icon versions, keyed by `${name}@${version}`. */
+		this._iconVersions = new Map();
+		this._iconsLoaded = false;
+		this._bgIconAborted = false;
 	}
 
 	refresh() {
+		this._bgIconAborted = true;
+		this._iconsLoaded = false;
+		this._iconVersions.clear();
 		this._onDidChangeTreeData.fire();
+	}
+
+	_startBackgroundIconLoad(appsData) {
+		this._bgIconAborted = false;
+		setImmediate(async () => {
+			try {
+				for (const app of appsData) {
+					if (this._bgIconAborted) return;
+					const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, false);
+					this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
+				}
+				if (!this._bgIconAborted) {
+					this._iconsLoaded = true;
+					this._onDidChangeTreeData.fire();
+				}
+			} catch (err) {
+				log('error', `Background app icon load failed: ${err.message}`);
+			}
+		});
 	}
 
 	getParent(element /* : Dependency */) {
@@ -54,11 +81,16 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			if (response === undefined) { return }
 			//#endregion Get apps list
 
-			const apps = await Promise.all(response.map(async (app) => {
-				const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, false);
+			const apps = response.map((app) => {
+				const iconVersion = this._iconVersions.get(`${app.name}@${app.version}`) ?? 0;
 				return new App(app.name, app.label, app.description, app.version, app.public, app.approved, app.theme, app.changes, iconVersion)
-			}));
+			});
 			apps.sort(Core.compareApps)
+
+			if (!this._iconsLoaded) {
+				this._startBackgroundIconLoad(response);
+			}
+
 			return apps
 		}
 		/*

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -21,31 +21,46 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		/** Resolved icon versions, keyed by `${name}@${version}`. */
 		this._iconVersions = new Map();
 		this._iconsLoaded = false;
-		this._bgIconAborted = false;
+		/** True while a background icon load is in flight (single-flight guard). */
+		this._iconsLoading = false;
+		/** Monotonic token identifying the current icon-load run. Bumping it cancels older runs. */
+		this._iconLoadToken = 0;
 	}
 
 	refresh() {
-		this._bgIconAborted = true;
+		// Invalidate any in-flight background load and reset state so icons are reloaded.
+		this._iconLoadToken++;
+		this._iconsLoading = false;
 		this._iconsLoaded = false;
 		this._iconVersions.clear();
 		this._onDidChangeTreeData.fire();
 	}
 
 	_startBackgroundIconLoad(appsData) {
-		this._bgIconAborted = false;
+		// Single-flight: never run two background loaders at once.
+		if (this._iconsLoading) return;
+		this._iconsLoading = true;
+		const token = ++this._iconLoadToken;
 		setImmediate(async () => {
 			try {
 				for (const app of appsData) {
-					if (this._bgIconAborted) return;
+					// Bail out if this run was superseded (refresh or a newer run).
+					if (token !== this._iconLoadToken) return;
 					const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, false);
+					if (token !== this._iconLoadToken) return;
 					this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
 				}
-				if (!this._bgIconAborted) {
+				if (token === this._iconLoadToken) {
 					this._iconsLoaded = true;
 					this._onDidChangeTreeData.fire();
 				}
 			} catch (err) {
 				log('error', `Background app icon load failed: ${err.message}`);
+			} finally {
+				// Release the single-flight lock only if we still own the current run.
+				if (token === this._iconLoadToken) {
+					this._iconsLoading = false;
+				}
 			}
 		});
 	}

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -46,9 +46,14 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 				for (const app of appsData) {
 					// Bail out if this run was superseded (refresh or a newer run).
 					if (token !== this._iconLoadToken) return;
-					const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, false);
-					if (token !== this._iconLoadToken) return;
-					this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
+					try {
+						const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, false);
+						if (token !== this._iconLoadToken) return;
+						this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
+					} catch (err) {
+						// Isolate per-app failures (e.g. a corrupt PNG) so one bad icon does not abort the whole batch.
+						log('error', `Background app icon load failed for ${app.name}@${app.version}: ${err.message}`);
+					}
 				}
 				if (token === this._iconLoadToken) {
 					this._iconsLoaded = true;

--- a/src/providers/OpensourceProvider.js
+++ b/src/providers/OpensourceProvider.js
@@ -7,6 +7,7 @@ const Code = require('../tree/Code')
 const Core = require('../Core');
 const camelCase = require('lodash/camelCase');
 const { downloadAndStoreAppIcon } = require('../libs/app-icon');
+const { log } = require('../output-channel');
 
 class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 	constructor(_authorization, _environment, _DIR) {
@@ -16,10 +17,36 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		this._environment = _environment;
 		this._baseUrl = _environment.baseUrl;
 		this._DIR = _DIR
+		/** Resolved icon versions, keyed by `${name}@${version}`. */
+		this._iconVersions = new Map();
+		this._iconsLoaded = false;
+		this._bgIconAborted = false;
 	}
 
 	refresh() {
+		this._bgIconAborted = true;
+		this._iconsLoaded = false;
+		this._iconVersions.clear();
 		this._onDidChangeTreeData.fire();
+	}
+
+	_startBackgroundIconLoad(appsData) {
+		this._bgIconAborted = false;
+		setImmediate(async () => {
+			try {
+				for (const app of appsData) {
+					if (this._bgIconAborted) return;
+					const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, true);
+					this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
+				}
+				if (!this._bgIconAborted) {
+					this._iconsLoaded = true;
+					this._onDidChangeTreeData.fire();
+				}
+			} catch (err) {
+				log('error', `Background example icon load failed: ${err.message}`);
+			}
+		});
 	}
 
 	getParent(element) {
@@ -53,11 +80,16 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			}
 			if (response === undefined) { return }
 
-			const apps = await Promise.all(response.map(async (app) => {
-				const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, true);
+			const apps = response.map((app) => {
+				const iconVersion = this._iconVersions.get(`${app.name}@${app.version}`) ?? 0;
 				return new App(app.name, app.label, app.description, app.version, app.public, app.approved, app.theme, app.changes, iconVersion, true);
-			}));
+			});
 			apps.sort(Core.compareApps)
+
+			if (!this._iconsLoaded) {
+				this._startBackgroundIconLoad(response);
+			}
+
 			return apps
 		}
 		/*

--- a/src/providers/OpensourceProvider.js
+++ b/src/providers/OpensourceProvider.js
@@ -45,9 +45,14 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 				for (const app of appsData) {
 					// Bail out if this run was superseded (refresh or a newer run).
 					if (token !== this._iconLoadToken) return;
-					const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, true);
-					if (token !== this._iconLoadToken) return;
-					this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
+					try {
+						const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, true);
+						if (token !== this._iconLoadToken) return;
+						this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
+					} catch (err) {
+						// Isolate per-app failures (e.g. a corrupt PNG) so one bad icon does not abort the whole batch.
+						log('error', `Background example icon load failed for ${app.name}@${app.version}: ${err.message}`);
+					}
 				}
 				if (token === this._iconLoadToken) {
 					this._iconsLoaded = true;

--- a/src/providers/OpensourceProvider.js
+++ b/src/providers/OpensourceProvider.js
@@ -20,31 +20,46 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		/** Resolved icon versions, keyed by `${name}@${version}`. */
 		this._iconVersions = new Map();
 		this._iconsLoaded = false;
-		this._bgIconAborted = false;
+		/** True while a background icon load is in flight (single-flight guard). */
+		this._iconsLoading = false;
+		/** Monotonic token identifying the current icon-load run. Bumping it cancels older runs. */
+		this._iconLoadToken = 0;
 	}
 
 	refresh() {
-		this._bgIconAborted = true;
+		// Invalidate any in-flight background load and reset state so icons are reloaded.
+		this._iconLoadToken++;
+		this._iconsLoading = false;
 		this._iconsLoaded = false;
 		this._iconVersions.clear();
 		this._onDidChangeTreeData.fire();
 	}
 
 	_startBackgroundIconLoad(appsData) {
-		this._bgIconAborted = false;
+		// Single-flight: never run two background loaders at once.
+		if (this._iconsLoading) return;
+		this._iconsLoading = true;
+		const token = ++this._iconLoadToken;
 		setImmediate(async () => {
 			try {
 				for (const app of appsData) {
-					if (this._bgIconAborted) return;
+					// Bail out if this run was superseded (refresh or a newer run).
+					if (token !== this._iconLoadToken) return;
 					const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, true);
+					if (token !== this._iconLoadToken) return;
 					this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
 				}
-				if (!this._bgIconAborted) {
+				if (token === this._iconLoadToken) {
 					this._iconsLoaded = true;
 					this._onDidChangeTreeData.fire();
 				}
 			} catch (err) {
 				log('error', `Background example icon load failed: ${err.message}`);
+			} finally {
+				// Release the single-flight lock only if we still own the current run.
+				if (token === this._iconLoadToken) {
+					this._iconsLoading = false;
+				}
 			}
 		});
 	}

--- a/src/providers/OpensourceProvider.js
+++ b/src/providers/OpensourceProvider.js
@@ -6,8 +6,7 @@ const Item = require('../tree/Item')
 const Code = require('../tree/Code')
 const Core = require('../Core');
 const camelCase = require('lodash/camelCase');
-const { downloadAndStoreAppIcon } = require('../libs/app-icon');
-const { log } = require('../output-channel');
+const { BackgroundIconLoader } = require('../libs/background-icon-loader');
 
 class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 	constructor(_authorization, _environment, _DIR) {
@@ -17,56 +16,20 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		this._environment = _environment;
 		this._baseUrl = _environment.baseUrl;
 		this._DIR = _DIR
-		/** Resolved icon versions, keyed by `${name}@${version}`. */
-		this._iconVersions = new Map();
-		this._iconsLoaded = false;
-		/** True while a background icon load is in flight (single-flight guard). */
-		this._iconsLoading = false;
-		/** Monotonic token identifying the current icon-load run. Bumping it cancels older runs. */
-		this._iconLoadToken = 0;
+		this._iconLoader = new BackgroundIconLoader({
+			baseUrl: this._baseUrl,
+			authorization: this._authorization,
+			environment: this._environment,
+			isOpensource: true,
+			logLabel: 'Background example',
+			onLoaded: () => this._onDidChangeTreeData.fire(),
+		});
 	}
 
 	refresh() {
-		// Invalidate any in-flight background load and reset state so icons are reloaded.
-		this._iconLoadToken++;
-		this._iconsLoading = false;
-		this._iconsLoaded = false;
-		this._iconVersions.clear();
+		// Invalidate any in-flight background icon load and reset state so icons are reloaded.
+		this._iconLoader.reset();
 		this._onDidChangeTreeData.fire();
-	}
-
-	_startBackgroundIconLoad(appsData) {
-		// Single-flight: never run two background loaders at once.
-		if (this._iconsLoading) return;
-		this._iconsLoading = true;
-		const token = ++this._iconLoadToken;
-		setImmediate(async () => {
-			try {
-				for (const app of appsData) {
-					// Bail out if this run was superseded (refresh or a newer run).
-					if (token !== this._iconLoadToken) return;
-					try {
-						const iconVersion = await downloadAndStoreAppIcon(app, this._baseUrl, this._authorization, this._environment, true);
-						if (token !== this._iconLoadToken) return;
-						this._iconVersions.set(`${app.name}@${app.version}`, iconVersion);
-					} catch (err) {
-						// Isolate per-app failures (e.g. a corrupt PNG) so one bad icon does not abort the whole batch.
-						log('error', `Background example icon load failed for ${app.name}@${app.version}: ${err.message}`);
-					}
-				}
-				if (token === this._iconLoadToken) {
-					this._iconsLoaded = true;
-					this._onDidChangeTreeData.fire();
-				}
-			} catch (err) {
-				log('error', `Background example icon load failed: ${err.message}`);
-			} finally {
-				// Release the single-flight lock only if we still own the current run.
-				if (token === this._iconLoadToken) {
-					this._iconsLoading = false;
-				}
-			}
-		});
 	}
 
 	getParent(element) {
@@ -101,13 +64,13 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			if (response === undefined) { return }
 
 			const apps = response.map((app) => {
-				const iconVersion = this._iconVersions.get(`${app.name}@${app.version}`) ?? 0;
+				const iconVersion = this._iconLoader.getIconVersion(app.name, app.version);
 				return new App(app.name, app.label, app.description, app.version, app.public, app.approved, app.theme, app.changes, iconVersion, true);
 			});
 			apps.sort(Core.compareApps)
 
-			if (!this._iconsLoaded) {
-				this._startBackgroundIconLoad(response);
+			if (!this._iconLoader.isLoaded) {
+				this._iconLoader.start(response);
 			}
 
 			return apps


### PR DESCRIPTION
https://make.atlassian.net/browse/IEN-15702

## Summary
- Renders the Custom apps (and Examples) tree immediately and downloads app icons in the **background**, refreshing once they are cached. This avoids blocking the initial load while every icon is fetched and processed.
- Fetches an individual app's icon **on demand** (forced fresh download) when opening **Edit icon**, so it no longer depends on the background batch and always reflects the current server icon.
- Adds a loading spinner in the icon webview plus a progress notification, with an error fallback so the panel stays usable (upload still works) if the fetch fails.

## Changes
- `src/providers/AppsProvider.js` - background icon loader with a resolved-version map, single completion refresh, abort/reset on refresh, and error logging.
- `src/providers/OpensourceProvider.js` - same background loading for the Examples tree.
- `src/libs/app-icon.ts` - optional `forceRedownload` parameter on `downloadAndStoreAppIcon`.
- `src/commands/AppCommands.js` - on-demand forced icon fetch in the Edit icon command, loading indicator, resolved-path cache-bust, and local error handling.

## Test plan
- [ ] Open the Custom apps view with many apps -> the list appears immediately, icons fill in shortly after.
- [ ] Confirm the tree does not enter a refresh loop while the view is open.
- [ ] Click **Edit icon** on an app -> spinner shows, the current icon loads, and uploading a new icon updates the tree.
- [ ] Simulate a fetch failure -> an error is shown and the icon panel still renders so a new icon can be uploaded.
