### PR TITLE
feat: add per-app component search

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,12 @@
 				"icon": "$(close)"
 			},
 			{
+				"command": "apps-sdk.app.search-components",
+				"title": "Search components...",
+				"category": "Make Apps",
+				"icon": "$(search)"
+			},
+			{
 				"command": "apps-sdk.refresh",
 				"title": "Refresh",
 				"category": "Make Apps",
@@ -533,6 +539,11 @@
 				}
 			],
 			"view/item/context": [
+				{
+					"command": "apps-sdk.app.search-components",
+					"group": "7_modification_online",
+					"when": "viewItem =~ /^app/ && view == apps"
+				},
 				{
 					"command": "apps-sdk.function.new",
 					"group": "7_modification_online",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import { type AppComponentType, AppComponentTypes } from './types/app-component-
 import { deleteLocalComponent } from './local-development/delete-local-component';
 import { catchError } from './error-handling';
 import { camelToKebab } from './utils/camel-to-kebab';
+import { contextGuard } from './Core';
 
 let client: vscodeLanguageclient.LanguageClient;
 
@@ -219,6 +220,49 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand('apps-sdk.search.clear', catchError('Clear custom apps search', async () => {
 		appsProvider.clearSearchFilter();
 		updateSearchContext();
+	}));
+
+	vscode.commands.registerCommand('apps-sdk.app.search-components', catchError('Search app components', async (app) => {
+		if (!contextGuard(app)) {
+			return;
+		}
+
+		const { components, failedGroups } = await vscode.window.withProgress(
+			{ location: vscode.ProgressLocation.Notification, title: `Loading components of ${app.bareLabel}…` },
+			() => appsProvider.getAppComponentsSummary(app),
+		);
+
+		if (components.length === 0) {
+			// Only claim the app is empty when nothing failed; a failed fetch already surfaced an
+			// error dialog (via rpGet), so showing "No components found" on top would be misleading.
+			if (failedGroups.length === 0) {
+				vscode.window.showInformationMessage('No components found in this app.');
+			}
+			return;
+		}
+
+		const items = components.map((summary: any) => ({
+			label: summary.label,
+			// `description` (the raw name/id) and `detail` are matched on too, so a name that
+			// differs from the label is still searchable.
+			description: summary.name,
+			detail: summary.supertype + (summary.description ? ` — ${summary.description}` : ''),
+			summary,
+		}));
+
+		const picked = await vscode.window.showQuickPick(items, {
+			matchOnDescription: true,
+			matchOnDetail: true,
+			placeHolder: 'Search components by name or label',
+		});
+		if (picked === undefined) {
+			return;
+		}
+
+		// Rebuild the component's tree node and reveal it. Deliberately NOT calling refresh()
+		// (that would clear the icon cache and restart background loading).
+		const item = appsProvider.buildComponentTreeItem(app, picked.summary);
+		await appsTreeView.reveal(item, { select: true, focus: true, expand: true });
 	}));
 
 	/**

--- a/src/libs/app-component-search.test.ts
+++ b/src/libs/app-component-search.test.ts
@@ -45,6 +45,49 @@ suite('app-component-search buildComponentTreeItem()', () => {
 		assert.strictEqual(item.name, 'getData', 'name carried through');
 		assert.strictEqual(item.supertype, 'module', 'supertype carried through');
 	});
+
+	test('Leaves changes empty when the app has none for the component', () => {
+		const item = buildComponentTreeItem(app, summary);
+		assert.deepStrictEqual(item.changes, [], 'no item changes');
+		assert.deepStrictEqual(item.parent.changes, [], 'no group changes');
+	});
+
+	test('Mirrors the app pending-changes onto the rebuilt group and item', () => {
+		const changes = [
+			{ group: 'module', item: 'getData', code: 'api', id: 1 },
+			{ group: 'module', item: 'other', code: 'api', id: 2 },
+			{ group: 'app', code: 'groups', id: 3 },
+		];
+		const appWithChanges = new (App as any)('myApp', 'My App', 'desc', 2, false, false, 'light', changes, 0);
+		const item = buildComponentTreeItem(appWithChanges, summary);
+		assert.deepStrictEqual(
+			item.changes,
+			[{ group: 'module', item: 'getData', code: 'api', id: 1 }],
+			'item changes are filtered by group and item name',
+		);
+		assert.deepStrictEqual(
+			item.parent.changes,
+			[
+				{ group: 'module', item: 'getData', code: 'api', id: 1 },
+				{ group: 'module', item: 'other', code: 'api', id: 2 },
+			],
+			'group changes keep the whole group but drop the synthetic "groups" change',
+		);
+	});
+
+	test('Normalizes account/hook change groups when matching connection/webhook components', () => {
+		const changes = [{ group: 'account', item: 'myConn', code: 'api', id: 1 }];
+		const appWithChanges = new (App as any)('myApp', 'My App', 'desc', 2, false, false, 'light', changes, 0);
+		const conn: AppComponentSummary = {
+			...summary,
+			name: 'myConn',
+			supertype: 'connection',
+			groupPlural: 'connections',
+			type: 'oauth',
+		};
+		const item = buildComponentTreeItem(appWithChanges, conn);
+		assert.deepStrictEqual(item.changes, changes, 'an "account" change maps to the connection component');
+	});
 });
 
 /**

--- a/src/libs/app-component-search.test.ts
+++ b/src/libs/app-component-search.test.ts
@@ -34,6 +34,12 @@ suite('app-component-search buildComponentTreeItem()', () => {
 		assert.strictEqual(item.parent.parent, app, 'Group parent is the real App node');
 	});
 
+	test('Humanizes the parent Group label to match the real tree', () => {
+		assert.strictEqual(buildComponentTreeItem(app, summary).parent.label, 'Modules', 'modules -> Modules');
+		const rpc: AppComponentSummary = { ...summary, groupPlural: 'rpcs', supertype: 'rpc' };
+		assert.strictEqual(buildComponentTreeItem(app, rpc).parent.label, 'Remote procedures', 'rpcs -> Remote procedures');
+	});
+
 	test('Preserves the component identity on the rebuilt node', () => {
 		const item = buildComponentTreeItem(app, summary);
 		assert.strictEqual(item.name, 'getData', 'name carried through');

--- a/src/libs/app-component-search.test.ts
+++ b/src/libs/app-component-search.test.ts
@@ -1,0 +1,107 @@
+import * as assert from 'node:assert';
+import { suite, test } from 'mocha';
+import App from '../tree/App';
+import {
+	buildComponentTreeItem,
+	toComponentSummary,
+	unwrapComponentsResponse,
+	type AppComponentSummary,
+} from './app-component-search';
+
+/**
+ * Locks the deterministic tree-id contract that `TreeView.reveal` relies on: a rebuilt
+ * component node must carry the exact ids `AppsProvider.getChildren` would produce, namely
+ * `<app.id>_<plural>_<name>` for the Item and `<app.id>_<plural>` for its parent Group.
+ */
+suite('app-component-search buildComponentTreeItem()', () => {
+	const app = new (App as any)('myApp', 'My App', 'desc', 2, false, false, 'light', [], 0);
+	const summary: AppComponentSummary = {
+		name: 'getData',
+		label: 'Get Data',
+		supertype: 'module',
+		groupPlural: 'modules',
+		type: 4,
+		public: false,
+		approved: false,
+		description: 'Fetches data',
+		crud: undefined,
+	};
+
+	test('Builds an Item whose id and parent Group id match the lazy tree', () => {
+		const item = buildComponentTreeItem(app, summary);
+		assert.strictEqual(item.id, 'myApp@2_modules_getData', 'Item id matches <app.id>_<plural>_<name>');
+		assert.strictEqual(item.parent.id, 'myApp@2_modules', 'Group id matches <app.id>_<plural>');
+		assert.strictEqual(item.parent.parent, app, 'Group parent is the real App node');
+	});
+
+	test('Preserves the component identity on the rebuilt node', () => {
+		const item = buildComponentTreeItem(app, summary);
+		assert.strictEqual(item.name, 'getData', 'name carried through');
+		assert.strictEqual(item.supertype, 'module', 'supertype carried through');
+	});
+});
+
+/**
+ * Coverage for the regression-prone parsing logic: v1 vs v2 response unwrapping.
+ */
+suite('app-component-search unwrapComponentsResponse()', () => {
+	test('v1 returns the response array directly', () => {
+		const input = [{ name: 'a' }, { name: 'b' }];
+		assert.deepStrictEqual(unwrapComponentsResponse(input, 'modules', 1), input);
+	});
+
+	test('v2 unwraps the appModules property', () => {
+		const input = { appModules: [{ name: 'a' }] };
+		assert.deepStrictEqual(unwrapComponentsResponse(input, 'modules', 2), [{ name: 'a' }]);
+	});
+
+	test('v2 unwraps the appRpcs property', () => {
+		const input = { appRpcs: [{ name: 'r' }] };
+		assert.deepStrictEqual(unwrapComponentsResponse(input, 'rpcs', 2), [{ name: 'r' }]);
+	});
+
+	test('Returns an empty array for a missing/undefined group', () => {
+		assert.deepStrictEqual(unwrapComponentsResponse({}, 'functions', 2), []);
+		assert.deepStrictEqual(unwrapComponentsResponse(undefined, 'functions', 2), []);
+	});
+});
+
+/**
+ * Coverage for the label fallback and field mapping, mirroring the tree's `Item` behavior.
+ */
+suite('app-component-search toComponentSummary()', () => {
+	test('Uses the label when present', () => {
+		const output: AppComponentSummary = {
+			name: 'createContact',
+			label: 'Create a Contact',
+			supertype: 'module',
+			groupPlural: 'modules',
+			type: 4,
+			public: undefined,
+			approved: undefined,
+			description: undefined,
+			crud: 'create',
+		};
+		assert.deepStrictEqual(
+			toComponentSummary(
+				{ name: 'createContact', label: 'Create a Contact', type: 4, crud: 'create' },
+				'module',
+				'modules',
+			),
+			output,
+		);
+	});
+
+	test('Falls back to name + args when the label is absent (functions)', () => {
+		const result = toComponentSummary({ name: 'getTime', args: '(date)' }, 'function', 'functions');
+		assert.strictEqual(result.label, 'getTime(date)', 'label is name concatenated with args');
+		assert.strictEqual(result.supertype, 'function', 'supertype is function');
+		assert.strictEqual(result.groupPlural, 'functions', 'groupPlural is functions');
+	});
+
+	test('Resolves the module type from type, type_id, or typeId', () => {
+		// eslint-disable-next-line camelcase -- mirrors the snake_case field returned by the Make v1 API
+		assert.strictEqual(toComponentSummary({ name: 'a', type_id: 9 }, 'module', 'modules').type, 9, 'type_id');
+		assert.strictEqual(toComponentSummary({ name: 'a', typeId: 10 }, 'module', 'modules').type, 10, 'typeId');
+	});
+});

--- a/src/libs/app-component-search.ts
+++ b/src/libs/app-component-search.ts
@@ -1,0 +1,151 @@
+import camelCase from 'lodash/camelCase';
+import * as Core from '../Core';
+import { log } from '../output-channel';
+import type { Environment } from '../types/environment.types';
+import Group from '../tree/Group';
+import Item from '../tree/Item';
+
+/**
+ * A flattened description of a single app component (connection, webhook, module,
+ * RPC or function) sufficient to display it in a Quick Pick and to rebuild the
+ * matching tree node for `TreeView.reveal`.
+ */
+export interface AppComponentSummary {
+	/** Internal component name (the API id). This is what the user searches by when it differs from the label. */
+	name: string;
+	/** Human-readable label (mirrors the tree's label fallbacks; functions fall back to `name + args`). */
+	label: string;
+	/** Singular component type, e.g. `module` / `rpc` (matches `Item.supertype`). */
+	supertype: string;
+	/** API plural used as the tree group id, e.g. `modules` / `rpcs`. */
+	groupPlural: string;
+	/** Module type id (only meaningful for modules); undefined otherwise. */
+	type: number | undefined;
+	public: boolean | undefined;
+	approved: boolean | undefined;
+	description: string | undefined;
+	crud: string | undefined;
+}
+
+interface FetchAppComponentsOptions {
+	baseUrl: string;
+	authorization: string;
+	environment: Environment;
+	appName: string;
+	appVersion: number;
+}
+
+export interface AppComponentsSummaryResult {
+	/** Flat list of all successfully fetched components. */
+	components: AppComponentSummary[];
+	/**
+	 * API plural names of the component groups whose fetch failed (e.g. `['modules']`).
+	 * Lets the caller distinguish a genuinely empty app from a failed load - the underlying
+	 * `rpGet` already surfaces an error dialog per failed group.
+	 */
+	failedGroups: string[];
+}
+
+/** API plural names of the component groups, in the order they should be listed. */
+const COMPONENT_GROUPS = ['connections', 'webhooks', 'modules', 'rpcs', 'functions'] as const;
+
+/**
+ * Unwraps the component list from a Make API response. v1 returns the array directly,
+ * while v2 nests it under `app<GroupPlural>` (e.g. `appModules`). Mirrors the level-2
+ * logic in `AppsProvider.getChildren`.
+ */
+export function unwrapComponentsResponse(response: any, groupPlural: string, version: number): any[] {
+	const items = version === 1 ? response : response?.[camelCase(`app_${groupPlural}`)];
+	return Array.isArray(items) ? items : [];
+}
+
+/**
+ * Maps a single raw API component to a flat summary, using the same label fallback as the
+ * tree (`Item`): a present `label` wins, otherwise functions fall back to `name + args`.
+ */
+export function toComponentSummary(item: any, supertype: string, groupPlural: string): AppComponentSummary {
+	return {
+		name: item.name,
+		label: item.label || `${item.name}${item.args ?? ''}`,
+		supertype,
+		groupPlural,
+		type: item.type || item.type_id || item.typeId,
+		public: item.public,
+		approved: item.approved,
+		description: item.description,
+		crud: item.crud,
+	};
+}
+
+/**
+ * Fetches the components of a single app across all five component types and returns the
+ * flattened summaries together with the API plural names of any groups whose fetch failed.
+ * Each type is fetched independently: a single failing/missing type is logged and skipped so
+ * the rest still resolve, and the caller can tell a genuinely empty app from a failed load.
+ *
+ * Faithfully mirrors the level-2 logic in `AppsProvider.getChildren`:
+ *  - connections/webhooks URIs omit the app version segment,
+ *  - the v2 response is unwrapped via `response[camelCase('app_<plural>')]`,
+ *  - the label uses the same fallback as the tree (`label || name + args`).
+ */
+export async function fetchAppComponentsSummary(
+	options: FetchAppComponentsOptions,
+): Promise<AppComponentsSummaryResult> {
+	const { baseUrl, authorization, environment, appName, appVersion } = options;
+
+	const perGroup = await Promise.all(
+		COMPONENT_GROUPS.map(
+			async (groupPlural): Promise<{ components: AppComponentSummary[]; failed: boolean }> => {
+				const supertype = groupPlural.slice(0, -1);
+				try {
+					const sdkPart = Core.pathDeterminer(environment.version, '__sdk');
+					const appPart = Core.pathDeterminer(environment.version, 'app');
+					const typePart = Core.pathDeterminer(environment.version, supertype);
+					const appBase = `${baseUrl}/${sdkPart}${appPart}/${appName}`;
+					// Connections and webhooks are not versioned; everything else needs the version segment.
+					const uri = Core.isVersionable(supertype)
+						? `${appBase}/${appVersion}/${typePart}`
+						: `${appBase}/${typePart}`;
+
+					const response = await Core.rpGet(uri, authorization);
+					const items = unwrapComponentsResponse(response, groupPlural, environment.version);
+					return { components: items.map((item) => toComponentSummary(item, supertype, groupPlural)), failed: false };
+				} catch (err: any) {
+					// Isolate per-type failures so one bad/missing endpoint does not break the whole search.
+					log('error', `App component search: failed to load ${groupPlural} of ${appName}: ${err.message}`);
+					return { components: [], failed: true };
+				}
+			},
+		),
+	);
+
+	return {
+		components: perGroup.flatMap((group) => group.components),
+		failedGroups: COMPONENT_GROUPS.filter((_, index) => perGroup[index].failed),
+	};
+}
+
+/**
+ * Rebuilds the tree node (`Item`) for a component so it can be passed to
+ * `TreeView.reveal`. The node ids are deterministic and match what
+ * `AppsProvider.getChildren` produces, which is what reveal matches on:
+ *   `App.id = name@version` -> `Group.id = <app.id>_<plural>` -> `Item.id = <group.id>_<name>`.
+ *
+ * @param appNode The real `App` tree node the command was invoked on (used as the ancestor).
+ * @param summary The picked component summary.
+ */
+export function buildComponentTreeItem(appNode: any, summary: AppComponentSummary): any {
+	const group = new (Group as any)(summary.groupPlural, summary.groupPlural, appNode, []);
+	return new (Item as any)(
+		summary.name,
+		summary.label,
+		group,
+		summary.supertype,
+		summary.type,
+		summary.public,
+		summary.approved,
+		[],
+		summary.description,
+		summary.crud,
+	);
+}

--- a/src/libs/app-component-search.ts
+++ b/src/libs/app-component-search.ts
@@ -19,8 +19,11 @@ export interface AppComponentSummary {
 	supertype: string;
 	/** API plural used as the tree group id, e.g. `modules` / `rpcs`. */
 	groupPlural: string;
-	/** Module type id (only meaningful for modules); undefined otherwise. */
-	type: number | undefined;
+	/**
+	 * Component type, mirroring `Item.type` in the tree model: a numeric type id for modules,
+	 * or a string (e.g. `'oauth'`) for connections; undefined for component types without a type.
+	 */
+	type: number | string | undefined;
 	public: boolean | undefined;
 	approved: boolean | undefined;
 	description: string | undefined;

--- a/src/libs/app-component-search.ts
+++ b/src/libs/app-component-search.ts
@@ -56,6 +56,19 @@ export interface AppComponentsSummaryResult {
 const COMPONENT_GROUPS = ['connections', 'webhooks', 'modules', 'rpcs', 'functions'] as const;
 
 /**
+ * Humanized group labels, mirroring the group labels built in `AppsProvider.getChildren`
+ * (note `rpcs` -> "Remote procedures", not a title-cased plural). Used so a node rebuilt for
+ * `TreeView.reveal` shows the same label/casing as the real tree.
+ */
+const GROUP_LABELS: Record<string, string> = {
+	connections: 'Connections',
+	webhooks: 'Webhooks',
+	modules: 'Modules',
+	rpcs: 'Remote procedures',
+	functions: 'Functions',
+};
+
+/**
  * Unwraps the component list from a Make API response. v1 returns the array directly,
  * while v2 nests it under `app<GroupPlural>` (e.g. `appModules`). Mirrors the level-2
  * logic in `AppsProvider.getChildren`.
@@ -142,7 +155,10 @@ export async function fetchAppComponentsSummary(
  * @param summary The picked component summary.
  */
 export function buildComponentTreeItem(appNode: any, summary: AppComponentSummary): any {
-	const group = new (Group as any)(summary.groupPlural, summary.groupPlural, appNode, []);
+	// The group `id` must stay `groupPlural` (that is what reveal matches on), but the label is
+	// humanized to match what `AppsProvider.getChildren` renders.
+	const groupLabel = GROUP_LABELS[summary.groupPlural] ?? summary.groupPlural;
+	const group = new (Group as any)(summary.groupPlural, groupLabel, appNode, []);
 	return new (Item as any)(
 		summary.name,
 		summary.label,

--- a/src/libs/app-component-search.ts
+++ b/src/libs/app-component-search.ts
@@ -132,7 +132,10 @@ export async function fetchAppComponentsSummary(
 					return { components: items.map((item) => toComponentSummary(item, supertype, groupPlural)), failed: false };
 				} catch (err: any) {
 					// Isolate per-type failures so one bad/missing endpoint does not break the whole search.
-					log('error', `App component search: failed to load ${groupPlural} of ${appName}: ${err.message}`);
+					// `rpGet` already logs at error level (via `showAndLogError`) before throwing, so log at
+					// `warn` here to avoid duplicate error noise; guard against `err` not being an `Error`.
+					const message = err instanceof Error ? err.message : String(err);
+					log('warn', `App component search: failed to load ${groupPlural} of ${appName}: ${message}`);
 					return { components: [], failed: true };
 				}
 			},
@@ -146,10 +149,30 @@ export async function fetchAppComponentsSummary(
 }
 
 /**
+ * Selects the pending-change records that belong to a given component group, mirroring the
+ * group filter in `AppsProvider.getChildren`: the API change `group` is normalized
+ * (`account` -> `connection`, `hook` -> `webhook`) and the synthetic `groups` change (the
+ * categories node) is excluded.
+ */
+function changesForGroup(appChanges: any, supertype: string): any[] {
+	if (!Array.isArray(appChanges)) {
+		return [];
+	}
+	return appChanges.filter((change: any) => {
+		const normalizedGroup =
+			change.group === 'account' ? 'connection' : change.group === 'hook' ? 'webhook' : change.group;
+		return normalizedGroup === supertype && change.code !== 'groups';
+	});
+}
+
+/**
  * Rebuilds the tree node (`Item`) for a component so it can be passed to
  * `TreeView.reveal`. The node ids are deterministic and match what
  * `AppsProvider.getChildren` produces, which is what reveal matches on:
  *   `App.id = name@version` -> `Group.id = <app.id>_<plural>` -> `Item.id = <group.id>_<name>`.
+ *
+ * The pending-change subsets are also rebuilt from `appNode.changes` (same filtering as the
+ * tree) so the revealed node renders the "changed" marker exactly like the lazily-built one.
  *
  * @param appNode The real `App` tree node the command was invoked on (used as the ancestor).
  * @param summary The picked component summary.
@@ -158,7 +181,9 @@ export function buildComponentTreeItem(appNode: any, summary: AppComponentSummar
 	// The group `id` must stay `groupPlural` (that is what reveal matches on), but the label is
 	// humanized to match what `AppsProvider.getChildren` renders.
 	const groupLabel = GROUP_LABELS[summary.groupPlural] ?? summary.groupPlural;
-	const group = new (Group as any)(summary.groupPlural, groupLabel, appNode, []);
+	const groupChanges = changesForGroup(appNode.changes, summary.supertype);
+	const itemChanges = groupChanges.filter((change: any) => change.item === summary.name);
+	const group = new (Group as any)(summary.groupPlural, groupLabel, appNode, groupChanges);
 	return new (Item as any)(
 		summary.name,
 		summary.label,
@@ -167,7 +192,7 @@ export function buildComponentTreeItem(appNode: any, summary: AppComponentSummar
 		summary.type,
 		summary.public,
 		summary.approved,
-		[],
+		itemChanges,
 		summary.description,
 		summary.crud,
 	);

--- a/src/libs/app-component-search.ts
+++ b/src/libs/app-component-search.ts
@@ -13,7 +13,10 @@ import Item from '../tree/Item';
 export interface AppComponentSummary {
 	/** Internal component name (the API id). This is what the user searches by when it differs from the label. */
 	name: string;
-	/** Human-readable label (mirrors the tree's label fallbacks; functions fall back to `name + args`). */
+	/**
+	 * Human-readable label: the API `label` if present, otherwise `name + args`. The fallback
+	 * applies to any component type, but in practice only functions lack a `label`.
+	 */
 	label: string;
 	/** Singular component type, e.g. `module` / `rpc` (matches `Item.supertype`). */
 	supertype: string;
@@ -63,8 +66,9 @@ export function unwrapComponentsResponse(response: any, groupPlural: string, ver
 }
 
 /**
- * Maps a single raw API component to a flat summary, using the same label fallback as the
- * tree (`Item`): a present `label` wins, otherwise functions fall back to `name + args`.
+ * Maps a single raw API component to a flat summary, using the same label handling as the
+ * tree (`Item`): a present `label` wins, otherwise it falls back to `name + args` regardless
+ * of component type (in practice only functions lack a `label`).
  */
 export function toComponentSummary(item: any, supertype: string, groupPlural: string): AppComponentSummary {
 	return {

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -7,6 +7,7 @@ const Code = require('../tree/Code')
 const Core = require('../Core');
 const camelCase = require('lodash/camelCase');
 const { BackgroundIconLoader } = require('../libs/background-icon-loader');
+const { fetchAppComponentsSummary, buildComponentTreeItem } = require('../libs/app-component-search');
 
 class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 	constructor(_authorization, _environment, _DIR, _admin) {
@@ -50,6 +51,33 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		// Invalidate any in-flight background icon load and reset state so icons are reloaded.
 		this._iconLoader.reset();
 		this._onDidChangeTreeData.fire();
+	}
+
+	/**
+	 * Fetches a flat summary of all components (connections, webhooks, modules, rpcs, functions)
+	 * of the given app, used by the per-app component search Quick Pick.
+	 * @param {object} appNode The App tree node.
+	 * @returns {Promise<{ components: Array, failedGroups: string[] }>} Component summaries plus
+	 *          the API plural names of any component groups whose fetch failed.
+	 */
+	getAppComponentsSummary(appNode) {
+		return fetchAppComponentsSummary({
+			baseUrl: this._baseUrl,
+			authorization: this._authorization,
+			environment: this._environment,
+			appName: appNode.name,
+			appVersion: appNode.version,
+		});
+	}
+
+	/**
+	 * Rebuilds the tree node for a component summary so it can be passed to `TreeView.reveal`.
+	 * @param {object} appNode The App tree node (ancestor).
+	 * @param {object} summary A component summary from `getAppComponentsSummary`.
+	 * @returns {object} An Item tree node with reveal-compatible ids.
+	 */
+	buildComponentTreeItem(appNode, summary) {
+		return buildComponentTreeItem(appNode, summary);
 	}
 
 	/**


### PR DESCRIPTION
Jira: https://make.atlassian.net/browse/IEN-15704

## Summary

Adds a per-app component search. Right-click an app in the **Custom apps** tree → **Search components...** opens a Quick Pick listing that app's connections, webhooks, modules, RPCs and functions, filterable by **label or name** (handy when a component's internal name differs from its label). Selecting a result reveals and selects the component in the tree.

## Details

- New shared helper `src/libs/app-component-search.ts`:
  - `fetchAppComponentsSummary()` fetches all five component types, faithfully mirroring the level-2 logic in `AppsProvider.getChildren` (v1/v2 response unwrap, unversioned connection/webhook URIs, tree label fallbacks). Each type is fetched independently so one failing/missing endpoint doesn't break the rest, and `failedGroups` lets the caller tell a genuinely empty app from a failed load.
  - `buildComponentTreeItem()` rebuilds a node with deterministic ids matching the lazy tree, so `TreeView.reveal` resolves it.
- `AppsProvider` exposes thin delegating methods (logic kept in `src/libs/` to avoid duplication across tree providers, per repo convention).
- New command `apps-sdk.app.search-components` (in `extension.ts`): `withProgress` fetch → Quick Pick (`matchOnDescription`/`matchOnDetail`) → `reveal`. Wrapped in `catchError`, guarded by `contextGuard`. Does **not** call `refresh()` (preserves the background icon cache).
- `package.json`: command contribution + `view/item/context` entry (`viewItem =~ /^app/`) so it appears on every app variant.

## Test plan

- [ ] Right-click an app → **Search components...**; verify the Quick Pick lists modules, RPCs, connections, webhooks and functions.
- [ ] Search by a component **name** that differs from its label → it still matches.
- [ ] Select a result → the component is revealed and selected in the tree (app/group auto-expand).
- [ ] App with no components → "No components found in this app."
- [ ] Unit tests: `src/libs/app-component-search.test.ts` (id contract, v1/v2 unwrap, label fallback) run in CI.

## Notes

- Hover-to-open navigation for `rpc://` / IML function references is intentionally out of scope; planned as a follow-up branch that will reuse this helper.
