### PR TITLE
feat(schemas): sync endpoint IMLJSON schemas with web zone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ The extension provides syntax support for Make-specific formats:
 - **IMLJSON** - JSON with embedded IML expressions. Grammar + schemas + snippets: `syntaxes/imljson/`
 - **Language Server** - Full LSP implementation in `syntaxes/imljson-language-features/server/` providing validation, completion, hover, formatting against JSON schemas.
 
-File types are validated against schemas in `syntaxes/imljson/schemas/` (parameters, api, common, base, scopes, etc.).
+File types are validated against schemas in `syntaxes/imljson/schemas/` (parameters, api, common, base, scopes, etc.). Not all schema associations are static files, though: `src/services/imljson-schema-associations.ts` also derives the Endpoint Input/Output Parameters schemas at runtime from `parameters.json`, and in online mode (API v2) dynamically enriches `api.json` per app+version with that app's real Endpoint names and Input Parameter suggestions (fetched and cached with a 60s TTL). Local development always gets the static/derived schemas only (free-string endpoint name).
 
 ## Build and Test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@integromat/iml": "^3.4.0",
 				"@integromat/udt": "^1.2.2",
+				"@makehq/forman-schema": "^1.15.0",
 				"@vscode/extension-telemetry": "^1.5.1",
 				"adm-zip": "^0.5.16",
 				"applicationinsights": "^3.14.0",
@@ -1252,6 +1253,15 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
+		"node_modules/@makehq/forman-schema": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@makehq/forman-schema/-/forman-schema-1.15.0.tgz",
+			"integrity": "sha512-r6P5BTPIj+rZmeKy+273KHX97mkiqzi3gPNgM7NQmpDGTFPZyiSs7Ovg9nwhIe+gu+xZHBdM+7R48/AFlHM23g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@microsoft/1ds-core-js": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,13 @@
 			},
 			{
 				"fileMatch": [
+					"**/endpoints/*/api.imljson",
+					"**/endpoints/*/*.communication.iml.json"
+				],
+				"url": "./syntaxes/imljson/schemas/endpoint-api.json"
+			},
+			{
+				"fileMatch": [
 					"samples.imljson",
 					"*.samples.iml.json"
 				],

--- a/package.json
+++ b/package.json
@@ -32,11 +32,7 @@
 			{
 				"fileMatch": [
 					"parameters.imljson",
-					"inputParameters.imljson",
-					"outputParameters.imljson",
-					"*.params.iml.json",
-					"*.input.iml.json",
-					"*.output.iml.json"
+					"*.params.iml.json"
 				],
 				"url": "./syntaxes/imljson/schemas/parameters.json"
 			},

--- a/package.json
+++ b/package.json
@@ -1070,6 +1070,7 @@
 	"dependencies": {
 		"@integromat/iml": "^3.4.0",
 		"@integromat/udt": "^1.2.2",
+		"@makehq/forman-schema": "^1.15.0",
 		"@vscode/extension-telemetry": "^1.5.1",
 		"adm-zip": "^0.5.16",
 		"applicationinsights": "^3.14.0",

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -281,6 +281,32 @@ suite('base.imljson timeout directive (online mode)', () => {
 	});
 });
 
+suite('inputParameters.imljson derived schema validation (online mode)', () => {
+	let documentUri: vscode.Uri;
+	let textDocument: vscode.TextDocument;
+	let e: vscode.TextEditor;
+
+	before(async () => {
+		documentUri = vscode.Uri.parse(tempy.file({ name: 'inputParameters.imljson' }));
+		await vscode.workspace.fs.writeFile(documentUri, new TextEncoder().encode(''));
+		textDocument = await vscode.workspace.openTextDocument(documentUri);
+		e = await vscode.window.showTextDocument(textDocument, 1, false);
+	});
+
+	after(async () => {
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor', documentUri);
+		await vscode.workspace.fs.delete(documentUri);
+	});
+
+	test('Flags a parameter missing `help`', async () => {
+		await setEditorContentAndWaitForDiagnosticsChange(e, '[{"name":"foo","type":"text"}]');
+		assert.deepStrictEqual(
+			vscode.languages.getDiagnostics(documentUri).map((problem) => problem.message),
+			['Missing property "help".'],
+		);
+	});
+});
+
 /**
  * Writes new `content` into and already opened file in VSCode editor
  * and waits for the "problems" section to be updated by background tasks.

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { after, before, suite } from 'mocha';
 import * as tempy from 'tempy';
 import * as vscode from 'vscode';
@@ -217,6 +219,65 @@ suite('App online file edit validations', () => {
 	// Close all forgotly opened files (but all should be already closed)
 	after(async () => {
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+	});
+});
+
+suite('Endpoint api.imljson combined schema validation (online mode)', () => {
+	let documentUri: vscode.Uri;
+	let textDocument: vscode.TextDocument;
+	let e: vscode.TextEditor;
+
+	before(async () => {
+		const endpointDir = path.join(tempy.directory(), 'endpoints', 'list-things');
+		fs.mkdirSync(endpointDir, { recursive: true });
+		documentUri = vscode.Uri.file(path.join(endpointDir, 'api.imljson'));
+		await vscode.workspace.fs.writeFile(documentUri, new TextEncoder().encode(''));
+		textDocument = await vscode.workspace.openTextDocument(documentUri);
+		e = await vscode.window.showTextDocument(textDocument, 1, false);
+	});
+
+	after(async () => {
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor', documentUri);
+		await vscode.workspace.fs.delete(documentUri);
+	});
+
+	test('Endpoint api.imljson flags the `endpoint` directive (combined with endpoint-api.json)', async () => {
+		await setEditorContentAndWaitForDiagnosticsChange(e, '{"endpoint":"x"}');
+
+		const problems = vscode.languages.getDiagnostics(documentUri);
+		assert.ok(
+			problems.some((problem) => problem.message === 'Matches a schema that is not allowed.'),
+			`Expected a "not allowed" diagnostic, got: ${problems.map((problem) => problem.message).join('; ')}`,
+		);
+	});
+});
+
+suite('base.imljson timeout directive (online mode)', () => {
+	let documentUri: vscode.Uri;
+	let textDocument: vscode.TextDocument;
+	let e: vscode.TextEditor;
+
+	before(async () => {
+		documentUri = vscode.Uri.parse(tempy.file({ name: 'base.imljson' }));
+		await vscode.workspace.fs.writeFile(documentUri, new TextEncoder().encode(''));
+		textDocument = await vscode.workspace.openTextDocument(documentUri);
+		e = await vscode.window.showTextDocument(textDocument, 1, false);
+	});
+
+	after(async () => {
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor', documentUri);
+		await vscode.workspace.fs.delete(documentUri);
+	});
+
+	test('Accepts a timeout within bounds, flags one over the maximum', async () => {
+		await setEditorContentAndWaitForDiagnosticsChange(e, '{"timeout":400000}');
+		assert.deepStrictEqual(
+			vscode.languages.getDiagnostics(documentUri).map((problem) => problem.message),
+			['Value is above the maximum of 300000.'],
+		);
+
+		await setEditorContentAndWaitForDiagnosticsChange(e, '{"timeout":30000}');
+		assert.deepStrictEqual(vscode.languages.getDiagnostics(documentUri), []);
 	});
 });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { registerCommandForLocalDevelopment } from './local-development';
 import * as LanguageServersSettings from './LanguageServersSettings';
 import {
 	getStaticAndDerivedSchemaAssociations,
+	ImljsonSchemaAssociations,
 	schemaAssociationsNotificationType,
 } from './services/imljson-schema-associations';
 import { AppsProvider } from './providers/AppsProvider';
@@ -244,6 +245,15 @@ export async function activate(context: vscode.ExtensionContext) {
 	 */
 	vscode.workspace.onWillSaveTextDocument((event) => coreCommands.sourceUpload(event));
 	vscode.window.onDidChangeActiveTextEditor((editor) => coreCommands.keepProviders(editor));
+
+	// Online-mode Endpoint schema enrichment (app endpoint names + input suggestions in api.imljson etc.).
+	const imljsonSchemaAssociations = new ImljsonSchemaAssociations({
+		client,
+		authorization: _authorization,
+		environment: _environment,
+	});
+	vscode.window.onDidChangeActiveTextEditor((editor) => imljsonSchemaAssociations.handleActiveEditorChange(editor));
+	await imljsonSchemaAssociations.handleActiveEditorChange(vscode.window.activeTextEditor);
 
 	/**
 	 * Registering JSONC formatter

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -253,7 +253,8 @@ export async function activate(context: vscode.ExtensionContext) {
 		environment: _environment,
 	});
 	vscode.window.onDidChangeActiveTextEditor((editor) => imljsonSchemaAssociations.handleActiveEditorChange(editor));
-	await imljsonSchemaAssociations.handleActiveEditorChange(vscode.window.activeTextEditor);
+	// Fire-and-forget: never throws, and activation shouldn't block on this API round-trip.
+	void imljsonSchemaAssociations.handleActiveEditorChange(vscode.window.activeTextEditor);
 
 	/**
 	 * Registering JSONC formatter

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,10 @@ import {
 } from './providers/configuration';
 import { registerCommandForLocalDevelopment } from './local-development';
 import * as LanguageServersSettings from './LanguageServersSettings';
+import {
+	getStaticAndDerivedSchemaAssociations,
+	schemaAssociationsNotificationType,
+} from './services/imljson-schema-associations';
 import { AppsProvider } from './providers/AppsProvider';
 import { OpensourceProvider } from './providers/OpensourceProvider';
 import ImljsonHoverProvider = require('./providers/ImljsonHoverProvider');
@@ -95,10 +99,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	await client.start();
 
 	// Register all JSON schemas for IMLJSON language
-	await client.sendNotification(
-		new vscodeLanguageclient.NotificationType('imljson/schemaAssociations'),
-		LanguageServersSettings.getJsonSchemas(),
-	);
+	await client.sendNotification(schemaAssociationsNotificationType, getStaticAndDerivedSchemaAssociations());
 
 	// Environment commands and envChanger
 	const envChanger = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10);

--- a/src/services/endpoint-api-enrichment.test.ts
+++ b/src/services/endpoint-api-enrichment.test.ts
@@ -192,6 +192,23 @@ suite('extractEndpointInputParameters()', () => {
 		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [{ name: 'items', description: '(array)' }]);
 	});
 
+	test('does not unwrap `schema` on a non-"json" item — only `type: "json"` wrappers are unwrapped', () => {
+		const parameters = [
+			{
+				name: 'config',
+				type: 'collection',
+				label: 'Config',
+				// A stray `schema` on a non-json field is not the wrapped-JSON-Schema convention; it must be
+				// ignored rather than replacing `config`'s own name with `foo`.
+				schema: { type: 'object', properties: { foo: { type: 'string' } } },
+			},
+		];
+
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
+			{ name: 'config', description: 'Config (collection)' },
+		]);
+	});
+
 	test('falls back to the bare name when schema is missing, empty, array/primitive-typed, or malformed', () => {
 		const parameters = [
 			{ name: 'noSchema', type: 'json' },

--- a/src/services/endpoint-api-enrichment.test.ts
+++ b/src/services/endpoint-api-enrichment.test.ts
@@ -48,7 +48,11 @@ suite('extractEndpointInputParameters()', () => {
 		assert.doesNotThrow(() => extractEndpointInputParameters(exotic));
 		assert.deepStrictEqual(extractEndpointInputParameters(exotic), [
 			{ name: 'inputSchema', description: '(json)' },
-			{ name: 'account', description: '(collection)' },
+			{
+				name: 'account',
+				description: '(collection)',
+				properties: [{ name: 'id', description: '(text)' }],
+			},
 		]);
 	});
 
@@ -95,7 +99,7 @@ suite('extractEndpointInputParameters()', () => {
 		]);
 	});
 
-	test('unwraps only one level — a nested object property is listed but not recursed into', () => {
+	test('recurses into a nested object property, surfacing its own sub-keys', () => {
 		const parameters = [
 			{
 				name: 'inputSchema',
@@ -110,8 +114,82 @@ suite('extractEndpointInputParameters()', () => {
 		];
 
 		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
-			{ name: 'address', description: '(collection)' },
+			{
+				name: 'address',
+				description: '(collection)',
+				properties: [{ name: 'city', description: '(text)' }],
+			},
 		]);
+	});
+
+	test('recurses through multiple levels (deeply nested objects)', () => {
+		const parameters = [
+			{
+				name: 'inputSchema',
+				type: 'json',
+				schema: {
+					type: 'object',
+					properties: {
+						id: { description: 'The unique identifier for a product', type: 'integer' },
+						name: { description: 'Name of the product', type: 'string' },
+						nested: {
+							description: 'blabla',
+							type: 'object',
+							properties: {
+								deep: { description: 'blabla', type: 'boolean' },
+							},
+						},
+					},
+					required: ['id', 'name'],
+				},
+			},
+		];
+
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
+			{ name: 'id', description: 'The unique identifier for a product (number) required' },
+			{ name: 'name', description: 'Name of the product (text) required' },
+			{
+				name: 'nested',
+				description: 'blabla (collection)',
+				properties: [{ name: 'deep', description: 'blabla (boolean)' }],
+			},
+		]);
+	});
+
+	test('a native (non-json) Forman `collection` field recurses the same way as an unwrapped JSON Schema', () => {
+		const parameters = [
+			{
+				name: 'address',
+				type: 'collection',
+				label: 'Address',
+				spec: [{ name: 'city', type: 'text', label: 'City' }],
+			},
+		];
+
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
+			{
+				name: 'address',
+				description: 'Address (collection)',
+				properties: [{ name: 'city', description: 'City (text)' }],
+			},
+		]);
+	});
+
+	test('does not recurse into an array field, even when its items are objects', () => {
+		const parameters = [
+			{
+				name: 'inputSchema',
+				type: 'json',
+				schema: {
+					type: 'object',
+					properties: {
+						items: { type: 'array', items: { type: 'object', properties: { sku: { type: 'string' } } } },
+					},
+				},
+			},
+		];
+
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [{ name: 'items', description: '(array)' }]);
 	});
 
 	test('falls back to the bare name when schema is missing, empty, array/primitive-typed, or malformed', () => {
@@ -217,5 +295,32 @@ suite('enrichApiSchemaWithEndpoints()', () => {
 		assert.deepStrictEqual(fallbackEntry.then.properties.pagination.properties.input.properties, {
 			page: { description: 'Page number' },
 		});
+	});
+
+	test('nested `properties` on an Input Parameter are injected recursively, still with no `required`/`additionalProperties`', () => {
+		const result = enrichApiSchemaWithEndpoints(apiSchema, [
+			{
+				name: 'listUsers',
+				inputParameters: [
+					{
+						name: 'address',
+						description: 'Address (collection)',
+						properties: [{ name: 'city', description: 'City (text)' }],
+					},
+				],
+			},
+		]);
+		const allOf = definitionsOf(result).request.allOf as Record<string, any>[];
+
+		const baseEntry = allOf.find((entry) => entry.then?.properties?.input && !entry.if?.properties?.pagination);
+		assert.ok(baseEntry);
+		assert.deepStrictEqual(baseEntry.then.properties.input.properties, {
+			address: {
+				description: 'Address (collection)',
+				properties: { city: { description: 'City (text)' } },
+			},
+		});
+		assert.strictEqual(baseEntry.then.properties.input.properties.address.additionalProperties, undefined);
+		assert.strictEqual(baseEntry.then.properties.input.properties.address.required, undefined);
 	});
 });

--- a/src/services/endpoint-api-enrichment.test.ts
+++ b/src/services/endpoint-api-enrichment.test.ts
@@ -1,0 +1,136 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { suite, test } from 'mocha';
+import { enrichApiSchemaWithEndpoints, extractEndpointInputParameters } from './endpoint-api-enrichment';
+
+function loadApiSchema(): Record<string, unknown> {
+	const schemaPath = path.join(__dirname, '../../syntaxes/imljson/schemas/api.json');
+	return JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as Record<string, unknown>;
+}
+
+function definitionsOf(schema: Record<string, unknown>): Record<string, Record<string, unknown>> {
+	return schema.definitions as Record<string, Record<string, unknown>>;
+}
+
+suite('extractEndpointInputParameters()', () => {
+	test('extracts names and descriptions from a JSON-string array', () => {
+		const json = JSON.stringify([{ name: 'cursor', label: 'Cursor', type: 'text', required: true }]);
+		assert.deepStrictEqual(extractEndpointInputParameters(json), [
+			{ name: 'cursor', description: 'Cursor (text) required' },
+		]);
+	});
+
+	test('extracts from an already-parsed array', () => {
+		assert.deepStrictEqual(extractEndpointInputParameters([{ name: 'cursor' }]), [
+			{ name: 'cursor', description: undefined },
+		]);
+	});
+
+	test('parses IMLJSON with comments (jsonc-parser deviation)', () => {
+		const jsonc = '[\n  // a comment\n  {"name":"cursor", "label":"Cursor"} /* trailing */\n]';
+		assert.deepStrictEqual(extractEndpointInputParameters(jsonc), [{ name: 'cursor', description: 'Cursor' }]);
+	});
+
+	test('returns an empty array for invalid JSON, a non-array value, or items without a string name', () => {
+		assert.deepStrictEqual(extractEndpointInputParameters('{not valid json'), []);
+		assert.deepStrictEqual(extractEndpointInputParameters({ name: 'not-an-array' }), []);
+		assert.deepStrictEqual(extractEndpointInputParameters([{ label: 'no name' }, 'a string item', null, 42]), []);
+	});
+
+	test('never throws on exotic parameter shapes (nested spec/schema, banners, …)', () => {
+		const exotic = [
+			{ name: 'inputSchema', type: 'json', schema: { type: 'object', properties: {} } },
+			{ name: 'account', type: 'collection', spec: [{ name: 'id', type: 'text' }] },
+			{ type: 'banner', title: 'Heads up' },
+		];
+
+		assert.doesNotThrow(() => extractEndpointInputParameters(exotic));
+		assert.deepStrictEqual(extractEndpointInputParameters(exotic), [
+			{ name: 'inputSchema', description: '(json)' },
+			{ name: 'account', description: '(collection)' },
+		]);
+	});
+});
+
+suite('enrichApiSchemaWithEndpoints()', () => {
+	const apiSchema = loadApiSchema();
+
+	test('constrains endpointName to the given endpoints (plus an IML expression)', () => {
+		const result = enrichApiSchemaWithEndpoints(apiSchema, [
+			{ name: 'getUser', inputParameters: [] },
+			{ name: 'listUsers', inputParameters: [] },
+		]);
+		const nameDef = definitionsOf(result).endpointName;
+
+		assert.deepStrictEqual(nameDef.oneOf, [
+			{ type: 'string', enum: ['getUser', 'listUsers'] },
+			{ $ref: 'sources.json#/definitions/stringWithIml' },
+		]);
+		assert.ok(nameDef.description, 'description is preserved so hover docs still work');
+	});
+
+	test('locks out every plain-string name (IML expression still allowed) when the app has zero endpoints', () => {
+		const result = enrichApiSchemaWithEndpoints(apiSchema, []);
+		assert.deepStrictEqual(definitionsOf(result).endpointName.oneOf, [
+			{ type: 'string', enum: [] },
+			{ $ref: 'sources.json#/definitions/stringWithIml' },
+		]);
+	});
+
+	test('does not mutate the input schema', () => {
+		const before = JSON.parse(JSON.stringify(apiSchema));
+		enrichApiSchemaWithEndpoints(apiSchema, [{ name: 'getUser', inputParameters: [] }]);
+		assert.deepStrictEqual(apiSchema, before);
+	});
+
+	test('injects 3 suggestion-only allOf entries for an endpoint with parameters, none without', () => {
+		const baseAllOfLength = (definitionsOf(apiSchema).request.allOf as unknown[]).length;
+
+		const withParams = enrichApiSchemaWithEndpoints(apiSchema, [
+			{ name: 'listUsers', inputParameters: [{ name: 'page', description: 'Page number' }] },
+		]);
+		assert.strictEqual((definitionsOf(withParams).request.allOf as unknown[]).length, baseAllOfLength + 3);
+
+		const withoutParams = enrichApiSchemaWithEndpoints(apiSchema, [{ name: 'getUser', inputParameters: [] }]);
+		assert.strictEqual((definitionsOf(withoutParams).request.allOf as unknown[]).length, baseAllOfLength);
+	});
+
+	test('the injected input-suggestion entries carry no `required`/`additionalProperties`', () => {
+		const result = enrichApiSchemaWithEndpoints(apiSchema, [
+			{ name: 'listUsers', inputParameters: [{ name: 'page', description: 'Page number' }] },
+		]);
+		const allOf = definitionsOf(result).request.allOf as Record<string, any>[];
+
+		const matchesListUsers = {
+			oneOf: [
+				{ const: 'listUsers' },
+				{ type: 'object', properties: { name: { const: 'listUsers' } }, required: ['name'] },
+			],
+		};
+
+		const baseEntry = allOf.find((entry) => entry.then?.properties?.input && !entry.if?.properties?.pagination);
+		assert.ok(baseEntry);
+		assert.deepStrictEqual(baseEntry.if, { required: ['endpoint'], properties: { endpoint: matchesListUsers } });
+		assert.deepStrictEqual(baseEntry.then.properties.input.properties, { page: { description: 'Page number' } });
+		assert.strictEqual(baseEntry.then.properties.input.additionalProperties, undefined);
+		assert.strictEqual(baseEntry.then.properties.input.required, undefined);
+
+		const overrideEntry = allOf.find((entry) => entry.if?.properties?.pagination?.required);
+		assert.ok(overrideEntry);
+		assert.deepStrictEqual(overrideEntry.if.properties.pagination.properties.endpoint, matchesListUsers);
+		assert.deepStrictEqual(overrideEntry.then.properties.pagination.properties.input.properties, {
+			page: { description: 'Page number' },
+		});
+
+		const fallbackEntry = allOf.find(
+			(entry) => entry.if?.properties?.pagination?.not && entry.if?.properties?.endpoint,
+		);
+		assert.ok(fallbackEntry);
+		assert.deepStrictEqual(fallbackEntry.if.properties.endpoint, matchesListUsers);
+		assert.deepStrictEqual(fallbackEntry.if.properties.pagination, { not: { required: ['endpoint'] } });
+		assert.deepStrictEqual(fallbackEntry.then.properties.pagination.properties.input.properties, {
+			page: { description: 'Page number' },
+		});
+	});
+});

--- a/src/services/endpoint-api-enrichment.test.ts
+++ b/src/services/endpoint-api-enrichment.test.ts
@@ -51,6 +51,91 @@ suite('extractEndpointInputParameters()', () => {
 			{ name: 'account', description: '(collection)' },
 		]);
 	});
+
+	test('unwraps a wrapped JSON Schema (type:"json" + schema) into flat suggestions, via @makehq/forman-schema', () => {
+		const parameters = [
+			{
+				name: 'inputSchema',
+				type: 'json',
+				schema: {
+					$schema: 'http://json-schema.org/draft-04/schema#',
+					title: 'Product',
+					description: 'A product from Acme catalog',
+					type: 'object',
+					properties: {
+						id: { description: 'The unique identifier for a product', type: 'integer' },
+						name: { description: 'Name of the product', type: 'string' },
+					},
+					required: ['id', 'name'],
+				},
+			},
+		];
+
+		// The wrapper's own name (`inputSchema`) is not a real `input` key at runtime, so it's replaced
+		// by the unwrapped properties rather than also appearing alongside them.
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
+			{ name: 'id', description: 'The unique identifier for a product (number) required' },
+			{ name: 'name', description: 'Name of the product (text) required' },
+		]);
+	});
+
+	test('extracts both an ordinary field and an unwrapped wrapped-schema field from a mixed array', () => {
+		const parameters = [
+			{ name: 'page', label: 'Page number', type: 'integer' },
+			{
+				name: 'inputSchema',
+				type: 'json',
+				schema: { type: 'object', properties: { id: { type: 'integer' } }, required: ['id'] },
+			},
+		];
+
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
+			{ name: 'page', description: 'Page number (integer)' },
+			{ name: 'id', description: '(number) required' },
+		]);
+	});
+
+	test('unwraps only one level — a nested object property is listed but not recursed into', () => {
+		const parameters = [
+			{
+				name: 'inputSchema',
+				type: 'json',
+				schema: {
+					type: 'object',
+					properties: {
+						address: { type: 'object', properties: { city: { type: 'string' } } },
+					},
+				},
+			},
+		];
+
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
+			{ name: 'address', description: '(collection)' },
+		]);
+	});
+
+	test('falls back to the bare name when schema is missing, empty, array/primitive-typed, or malformed', () => {
+		const parameters = [
+			{ name: 'noSchema', type: 'json' },
+			{ name: 'emptyObjectSchema', type: 'json', schema: { type: 'object' } },
+			{ name: 'emptyPropsSchema', type: 'json', schema: { type: 'object', properties: {} } },
+			{ name: 'arraySchema', type: 'json', schema: { type: 'array', items: { type: 'string' } } },
+			{ name: 'primitiveSchema', type: 'json', schema: { type: 'string' } },
+			{ name: 'garbageSchema', type: 'json', schema: 'not an object' },
+			{ name: 'nullSchema', type: 'json', schema: null },
+		];
+
+		assert.doesNotThrow(() => extractEndpointInputParameters(parameters));
+		assert.deepStrictEqual(extractEndpointInputParameters(parameters), [
+			{ name: 'noSchema', description: '(json)' },
+			{ name: 'emptyObjectSchema', description: '(json)' },
+			{ name: 'emptyPropsSchema', description: '(json)' },
+			{ name: 'arraySchema', description: '(json)' },
+			{ name: 'primitiveSchema', description: '(json)' },
+			{ name: 'garbageSchema', description: '(json)' },
+			{ name: 'nullSchema', description: '(json)' },
+		]);
+	});
 });
 
 suite('enrichApiSchemaWithEndpoints()', () => {

--- a/src/services/endpoint-api-enrichment.ts
+++ b/src/services/endpoint-api-enrichment.ts
@@ -1,4 +1,6 @@
+import { toFormanSchema, type FormanSchemaField } from '@makehq/forman-schema';
 import * as jsoncParser from 'jsonc-parser';
+import type { JSONSchema7 } from 'json-schema';
 
 /**
  * Suggestion for an Endpoint input parameter's key, surfaced when a module references that Endpoint.
@@ -20,15 +22,69 @@ const _isPrimitive = (value: unknown): value is string | number | boolean =>
 	typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
 
 /**
+ * Builds a `{name, description}` suggestion from a Forman Schema field, or `undefined` if it has no
+ * (string) `name`. `label` is preferred for the description text — the raw API's Input Parameters use
+ * it — falling back to `help` (the only descriptive text `toFormanSchema` produces, from a JSON Schema's
+ * `description`).
+ */
+function _toSuggestion(field: FormanSchemaField): EndpointInputParameter | undefined {
+	if (typeof field.name !== 'string') {
+		return undefined;
+	}
+
+	const descriptionParts = [
+		_isPrimitive(field.label) ? String(field.label) : _isPrimitive(field.help) ? String(field.help) : undefined,
+		_isPrimitive(field.type) ? `(${field.type})` : undefined,
+		field.required === true ? 'required' : undefined,
+	].filter((part): part is string => part !== undefined);
+
+	return { name: field.name, description: descriptionParts.length ? descriptionParts.join(' ') : undefined };
+}
+
+/**
+ * Unwraps a `type: 'json'` parameter's `schema` (a raw JSON Schema — e.g. describing the endpoint's whole
+ * input as `{type:'object', properties:{...}}`) into flat suggestions, via `@makehq/forman-schema`'s
+ * `toFormanSchema` — Make's own JSON-Schema-to-Forman-Schema converter, used here instead of a bespoke
+ * `properties` walker so this stays correct as that mapping evolves.
+ *
+ * Only one level is surfaced (`converted.spec`'s own entries, not their nested `.spec`), since this feeds
+ * a flat `input`/`pagination.input` key-completion list, not a nested one. Bails to `[]` for anything
+ * that isn't a non-null object, that `toFormanSchema` rejects (it throws on malformed input), or that
+ * doesn't convert to named sub-fields (e.g. an array or primitive JSON Schema has no `spec` array).
+ */
+function _extractFromJsonSchema(schema: unknown): EndpointInputParameter[] {
+	if (typeof schema !== 'object' || schema === null) {
+		return [];
+	}
+
+	let converted: FormanSchemaField;
+	try {
+		converted = toFormanSchema(schema as JSONSchema7);
+	} catch {
+		return [];
+	}
+
+	if (!Array.isArray(converted.spec)) {
+		return [];
+	}
+
+	return converted.spec
+		.map(_toSuggestion)
+		.filter((suggestion): suggestion is EndpointInputParameter => suggestion !== undefined);
+}
+
+/**
  * Extracts `{name, description}` suggestions from an Endpoint's raw Input Parameters section (the
  * `inputParameters` field of the `.../endpoints/{name}` API response — an IMLJSON string, or an
  * already-parsed value).
  *
- * Suggestions-only, never validation: the parameters section can have exotic shapes (nested `spec`,
- * `json`-type `schema`, …) this helper doesn't need to understand, so anything that isn't a plain array
- * of named parameters — a parse failure, a non-array value, an item without a string `name`, … — is
- * silently skipped rather than throwing. Only top-level names are extracted; nesting (`spec`, `schema`)
- * is ignored.
+ * Suggestions-only, never validation: the parameters section can have exotic shapes this helper doesn't
+ * need to fully understand, so anything that isn't a plain array of Forman Schema fields — a parse
+ * failure, a non-array value, an item without a string `name`, … — is silently skipped rather than
+ * throwing. Top-level names are extracted; a `type: 'json'` item's `schema` is also unwrapped one level
+ * (see {@link _extractFromJsonSchema}) — when that yields anything, it *replaces* the item's own
+ * name/label, since a wrapped-schema item's own name (conventionally `inputSchema`/`outputSchema`, see
+ * `endpoint-parameters-schema.ts`) isn't a real `input` key at runtime.
  *
  * Deviation from the ported web-zone original: the raw section is IMLJSON and may contain comments, so a
  * string value is parsed with `jsonc-parser` (already a dependency here) instead of `JSON.parse`.
@@ -48,23 +104,20 @@ export function extractEndpointInputParameters(value: unknown): EndpointInputPar
 
 	const result: EndpointInputParameter[] = [];
 	for (const item of parameters) {
-		if (typeof item !== 'object' || item === null || typeof (item as { name?: unknown }).name !== 'string') {
+		if (typeof item !== 'object' || item === null) {
 			continue;
 		}
 
-		const { name, label, type, required } = item as {
-			name: string;
-			label?: unknown;
-			type?: unknown;
-			required?: unknown;
-		};
-		const descriptionParts = [
-			_isPrimitive(label) ? String(label) : undefined,
-			_isPrimitive(type) ? `(${type})` : undefined,
-			required === true ? 'required' : undefined,
-		].filter((part): part is string => part !== undefined);
+		const unwrapped = _extractFromJsonSchema((item as { schema?: unknown }).schema);
+		if (unwrapped.length > 0) {
+			result.push(...unwrapped);
+			continue;
+		}
 
-		result.push({ name, description: descriptionParts.length ? descriptionParts.join(' ') : undefined });
+		const suggestion = _toSuggestion(item as FormanSchemaField);
+		if (suggestion) {
+			result.push(suggestion);
+		}
 	}
 
 	return result;

--- a/src/services/endpoint-api-enrichment.ts
+++ b/src/services/endpoint-api-enrichment.ts
@@ -8,6 +8,12 @@ import type { JSONSchema7 } from 'json-schema';
 export interface EndpointInputParameter {
 	name: string;
 	description?: string;
+	/**
+	 * Nested key suggestions, when this parameter is a `collection` with known sub-fields — see
+	 * {@link _toSuggestion}. Absent for leaves, including `array` fields (see there for why arrays don't
+	 * recurse).
+	 */
+	properties?: EndpointInputParameter[];
 }
 
 /**
@@ -26,6 +32,14 @@ const _isPrimitive = (value: unknown): value is string | number | boolean =>
  * (string) `name`. `label` is preferred for the description text — the raw API's Input Parameters use
  * it — falling back to `help` (the only descriptive text `toFormanSchema` produces, from a JSON Schema's
  * `description`).
+ *
+ * Recurses into `field.spec` when `field.type === 'collection'`, attaching the result as `properties` —
+ * this is the one function shared by both the raw-item path and the JSON-Schema-unwrap path (see
+ * {@link _extractFromJsonSchema}), so a nested object surfaces its own nested keys regardless of which
+ * path produced it. Deliberately excludes `type: 'array'`: an array's `.spec` describes its *item*
+ * shape, not a property bag of the array field itself (a real "sku" item-property isn't a direct
+ * `arrayField.sku` key — it belongs to each array element), so treating it the same as a `collection`
+ * would suggest a key that doesn't actually exist at that path.
  */
 function _toSuggestion(field: FormanSchemaField): EndpointInputParameter | undefined {
 	if (typeof field.name !== 'string') {
@@ -38,19 +52,31 @@ function _toSuggestion(field: FormanSchemaField): EndpointInputParameter | undef
 		field.required === true ? 'required' : undefined,
 	].filter((part): part is string => part !== undefined);
 
-	return { name: field.name, description: descriptionParts.length ? descriptionParts.join(' ') : undefined };
+	const properties =
+		field.type === 'collection' && Array.isArray(field.spec)
+			? field.spec
+					.map(_toSuggestion)
+					.filter((suggestion): suggestion is EndpointInputParameter => suggestion !== undefined)
+			: undefined;
+
+	return {
+		name: field.name,
+		description: descriptionParts.length ? descriptionParts.join(' ') : undefined,
+		...(properties?.length ? { properties } : {}),
+	};
 }
 
 /**
  * Unwraps a `type: 'json'` parameter's `schema` (a raw JSON Schema — e.g. describing the endpoint's whole
- * input as `{type:'object', properties:{...}}`) into flat suggestions, via `@makehq/forman-schema`'s
+ * input as `{type:'object', properties:{...}}`) into suggestions, via `@makehq/forman-schema`'s
  * `toFormanSchema` — Make's own JSON-Schema-to-Forman-Schema converter, used here instead of a bespoke
  * `properties` walker so this stays correct as that mapping evolves.
  *
- * Only one level is surfaced (`converted.spec`'s own entries, not their nested `.spec`), since this feeds
- * a flat `input`/`pagination.input` key-completion list, not a nested one. Bails to `[]` for anything
- * that isn't a non-null object, that `toFormanSchema` rejects (it throws on malformed input), or that
- * doesn't convert to named sub-fields (e.g. an array or primitive JSON Schema has no `spec` array).
+ * `converted.spec`'s entries are turned into suggestions via {@link _toSuggestion}, which recurses into
+ * nested `collection`-typed properties on its own — see there for how deep that goes and why `array`
+ * properties don't. Bails to `[]` for anything that isn't a non-null object, that `toFormanSchema` rejects
+ * (it throws on malformed input), or that doesn't convert to named sub-fields (e.g. an array or primitive
+ * JSON Schema has no `spec` array).
  */
 function _extractFromJsonSchema(schema: unknown): EndpointInputParameter[] {
 	if (typeof schema !== 'object' || schema === null) {
@@ -81,7 +107,8 @@ function _extractFromJsonSchema(schema: unknown): EndpointInputParameter[] {
  * Suggestions-only, never validation: the parameters section can have exotic shapes this helper doesn't
  * need to fully understand, so anything that isn't a plain array of Forman Schema fields — a parse
  * failure, a non-array value, an item without a string `name`, … — is silently skipped rather than
- * throwing. Top-level names are extracted; a `type: 'json'` item's `schema` is also unwrapped one level
+ * throwing. Names are extracted recursively into nested `collection`-typed sub-fields (see
+ * {@link _toSuggestion}); a `type: 'json'` item's `schema` is also unwrapped, recursively, the same way
  * (see {@link _extractFromJsonSchema}) — when that yields anything, it *replaces* the item's own
  * name/label, since a wrapped-schema item's own name (conventionally `inputSchema`/`outputSchema`, see
  * `endpoint-parameters-schema.ts`) isn't a real `input` key at runtime.
@@ -139,16 +166,34 @@ function _endpointNameIs(endpointName: string): Record<string, unknown> {
 }
 
 /**
+ * Recursively turns `EndpointInputParameter[]` into a JSON Schema `properties` map: `description` per
+ * key, plus a nested `properties` map when that parameter itself carries sub-fields. No `type`,
+ * `additionalProperties`, or `required` at any depth, so this stays suggestion-only all the way down —
+ * see {@link _buildInputSuggestionEntries}.
+ */
+function _buildPropertiesSchema(parameters: EndpointInputParameter[]): Record<string, unknown> {
+	return Object.fromEntries(
+		parameters.map(({ name, description, properties }) => [
+			name,
+			{
+				...(description ? { description } : {}),
+				...(properties?.length ? { properties: _buildPropertiesSchema(properties) } : {}),
+			},
+		]),
+	);
+}
+
+/**
  * Builds the `request.allOf` entries that turn each endpoint's known Input Parameters into
  * suggestion-only `input`/`pagination.input` key completions: one entry for the base `input`, one for
  * `pagination.input` when `pagination.endpoint` overrides the endpoint, and a fallback for
  * `pagination.input` when `pagination` has no `endpoint` override (so it reuses the base endpoint's
  * parameters). Endpoints without parameters contribute nothing.
  *
- * The injected `properties` carry no `additionalProperties` and no `required`, so the editor offers the
- * keys (with hover docs) in completion but can never flag an unknown or missing key — this is a
- * suggestion, not validation, because the parameters section can have shapes (nested `spec`, `json`
- * `schema`, …) this helper never inspects.
+ * The injected `properties` carry no `additionalProperties` and no `required` at any depth (see
+ * {@link _buildPropertiesSchema}), so the editor offers the keys (with hover docs) in completion but can
+ * never flag an unknown or missing key — this is a suggestion, not validation, because the parameters
+ * section can have shapes (`json` `schema`, …) this helper never inspects.
  */
 function _buildInputSuggestionEntries(endpoints: SdkEndpointSchemaInfo[]): Record<string, unknown>[] {
 	const entries: Record<string, unknown>[] = [];
@@ -158,9 +203,7 @@ function _buildInputSuggestionEntries(endpoints: SdkEndpointSchemaInfo[]): Recor
 			continue;
 		}
 
-		const properties = Object.fromEntries(
-			endpoint.inputParameters.map(({ name, description }) => [name, description ? { description } : {}]),
-		);
+		const properties = _buildPropertiesSchema(endpoint.inputParameters);
 
 		entries.push(
 			{

--- a/src/services/endpoint-api-enrichment.ts
+++ b/src/services/endpoint-api-enrichment.ts
@@ -135,10 +135,12 @@ export function extractEndpointInputParameters(value: unknown): EndpointInputPar
 			continue;
 		}
 
-		const unwrapped = _extractFromJsonSchema((item as { schema?: unknown }).schema);
-		if (unwrapped.length > 0) {
-			result.push(...unwrapped);
-			continue;
+		if ((item as { type?: unknown }).type === 'json') {
+			const unwrapped = _extractFromJsonSchema((item as { schema?: unknown }).schema);
+			if (unwrapped.length > 0) {
+				result.push(...unwrapped);
+				continue;
+			}
 		}
 
 		const suggestion = _toSuggestion(item as FormanSchemaField);

--- a/src/services/endpoint-api-enrichment.ts
+++ b/src/services/endpoint-api-enrichment.ts
@@ -1,0 +1,180 @@
+import * as jsoncParser from 'jsonc-parser';
+
+/**
+ * Suggestion for an Endpoint input parameter's key, surfaced when a module references that Endpoint.
+ */
+export interface EndpointInputParameter {
+	name: string;
+	description?: string;
+}
+
+/**
+ * The subset of an app's Endpoint metadata needed to enrich api.json for online-mode validation.
+ */
+export interface SdkEndpointSchemaInfo {
+	name: string;
+	inputParameters: EndpointInputParameter[];
+}
+
+const _isPrimitive = (value: unknown): value is string | number | boolean =>
+	typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+
+/**
+ * Extracts `{name, description}` suggestions from an Endpoint's raw Input Parameters section (the
+ * `inputParameters` field of the `.../endpoints/{name}` API response — an IMLJSON string, or an
+ * already-parsed value).
+ *
+ * Suggestions-only, never validation: the parameters section can have exotic shapes (nested `spec`,
+ * `json`-type `schema`, …) this helper doesn't need to understand, so anything that isn't a plain array
+ * of named parameters — a parse failure, a non-array value, an item without a string `name`, … — is
+ * silently skipped rather than throwing. Only top-level names are extracted; nesting (`spec`, `schema`)
+ * is ignored.
+ *
+ * Deviation from the ported web-zone original: the raw section is IMLJSON and may contain comments, so a
+ * string value is parsed with `jsonc-parser` (already a dependency here) instead of `JSON.parse`.
+ *
+ * @param value - The endpoint's raw `inputParameters` field.
+ * @returns The extracted suggestions, or `[]` if `value` isn't (or doesn't parse to) an array.
+ */
+export function extractEndpointInputParameters(value: unknown): EndpointInputParameter[] {
+	let parameters = value;
+	if (typeof parameters === 'string') {
+		parameters = jsoncParser.parse(parameters);
+	}
+
+	if (!Array.isArray(parameters)) {
+		return [];
+	}
+
+	const result: EndpointInputParameter[] = [];
+	for (const item of parameters) {
+		if (typeof item !== 'object' || item === null || typeof (item as { name?: unknown }).name !== 'string') {
+			continue;
+		}
+
+		const { name, label, type, required } = item as {
+			name: string;
+			label?: unknown;
+			type?: unknown;
+			required?: unknown;
+		};
+		const descriptionParts = [
+			_isPrimitive(label) ? String(label) : undefined,
+			_isPrimitive(type) ? `(${type})` : undefined,
+			required === true ? 'required' : undefined,
+		].filter((part): part is string => part !== undefined);
+
+		result.push({ name, description: descriptionParts.length ? descriptionParts.join(' ') : undefined });
+	}
+
+	return result;
+}
+
+/**
+ * `endpoint`/`pagination.endpoint` accept either the shorthand string form or the `{name, ...}` object
+ * form (see api.json), so matching "this endpoint reference is named X" must check both. The object
+ * branch needs an explicit `type: 'object'` guard — otherwise `properties`/`required` are no-ops against
+ * a plain string, so it would (incorrectly) match every string value.
+ */
+function _endpointNameIs(endpointName: string): Record<string, unknown> {
+	return {
+		oneOf: [
+			{ const: endpointName },
+			{ type: 'object', properties: { name: { const: endpointName } }, required: ['name'] },
+		],
+	};
+}
+
+/**
+ * Builds the `request.allOf` entries that turn each endpoint's known Input Parameters into
+ * suggestion-only `input`/`pagination.input` key completions: one entry for the base `input`, one for
+ * `pagination.input` when `pagination.endpoint` overrides the endpoint, and a fallback for
+ * `pagination.input` when `pagination` has no `endpoint` override (so it reuses the base endpoint's
+ * parameters). Endpoints without parameters contribute nothing.
+ *
+ * The injected `properties` carry no `additionalProperties` and no `required`, so the editor offers the
+ * keys (with hover docs) in completion but can never flag an unknown or missing key — this is a
+ * suggestion, not validation, because the parameters section can have shapes (nested `spec`, `json`
+ * `schema`, …) this helper never inspects.
+ */
+function _buildInputSuggestionEntries(endpoints: SdkEndpointSchemaInfo[]): Record<string, unknown>[] {
+	const entries: Record<string, unknown>[] = [];
+
+	for (const endpoint of endpoints) {
+		if (!endpoint.inputParameters.length) {
+			continue;
+		}
+
+		const properties = Object.fromEntries(
+			endpoint.inputParameters.map(({ name, description }) => [name, description ? { description } : {}]),
+		);
+
+		entries.push(
+			{
+				if: { required: ['endpoint'], properties: { endpoint: _endpointNameIs(endpoint.name) } },
+				then: { properties: { input: { properties } } },
+			},
+			{
+				if: {
+					required: ['pagination'],
+					properties: {
+						pagination: {
+							required: ['endpoint'],
+							properties: { endpoint: _endpointNameIs(endpoint.name) },
+						},
+					},
+				},
+				then: { properties: { pagination: { properties: { input: { properties } } } } },
+			},
+			{
+				if: {
+					required: ['endpoint', 'pagination'],
+					properties: {
+						endpoint: _endpointNameIs(endpoint.name),
+						pagination: { not: { required: ['endpoint'] } },
+					},
+				},
+				then: { properties: { pagination: { properties: { input: { properties } } } } },
+			},
+		);
+	}
+
+	return entries;
+}
+
+/**
+ * Returns a copy of api.json with `definitions.endpointName` constrained to the given endpoints' names
+ * (shared by `endpoint.name` and `pagination.endpoint.name`), so a module's Endpoint reference validates
+ * against — and autocompletes from — the app's existing endpoints. An IML expression (`{{ }}`) is still
+ * accepted for a dynamic name.
+ *
+ * Also appends, per endpoint with known Input Parameters, suggestion-only completions for the keys of
+ * `input`/`pagination.input` — see {@link extractEndpointInputParameters}.
+ *
+ * The caller decides whether the app's endpoint list is known at all; this function always receives a
+ * concrete array (an empty array still narrows `name` to "no valid plain-string value", an IML
+ * expression is still accepted).
+ *
+ * @param apiSchema - The parsed `syntaxes/imljson/schemas/api.json` content. Not mutated.
+ * @param endpoints - The app's endpoints, with known Input Parameters where available.
+ * @returns A deep-copied, endpoint-enriched variant of `apiSchema`.
+ */
+export function enrichApiSchemaWithEndpoints(
+	apiSchema: Record<string, unknown>,
+	endpoints: SdkEndpointSchemaInfo[],
+): Record<string, unknown> {
+	const schema = JSON.parse(JSON.stringify(apiSchema)) as Record<string, unknown>;
+	const definitions = schema.definitions as Record<string, Record<string, unknown>>;
+
+	const endpointNames = endpoints.map((endpoint) => endpoint.name);
+	const nameDef = definitions.endpointName;
+	definitions.endpointName = {
+		description: nameDef.description,
+		oneOf: [{ type: 'string', enum: [...endpointNames] }, { $ref: 'sources.json#/definitions/stringWithIml' }],
+	};
+
+	const request = definitions.request;
+	request.allOf = [...(request.allOf as unknown[]), ..._buildInputSuggestionEntries(endpoints)];
+
+	return schema;
+}

--- a/src/services/endpoint-parameters-schema.test.ts
+++ b/src/services/endpoint-parameters-schema.test.ts
@@ -1,0 +1,85 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { suite, test } from 'mocha';
+import { buildEndpointParametersSchema } from './endpoint-parameters-schema';
+
+function loadParametersSchema(): Record<string, unknown> {
+	const schemaPath = path.join(__dirname, '../../syntaxes/imljson/schemas/parameters.json');
+	return JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as Record<string, unknown>;
+}
+
+function definitionsOf(schema: Record<string, unknown>): Record<string, Record<string, unknown>> {
+	return schema.definitions as Record<string, Record<string, unknown>>;
+}
+
+suite('buildEndpointParametersSchema()', () => {
+	const parametersSchema = loadParametersSchema();
+
+	test('adds `help` to the shared `parameter` definition, and stays idempotent', () => {
+		const result = buildEndpointParametersSchema(parametersSchema, 'inputSchema');
+		const required = definitionsOf(result).parameter.required as string[];
+		assert.ok(required.includes('help'));
+		assert.ok(required.includes('type'), 'existing required entries are preserved');
+
+		// Feeding an already-derived schema back in must not duplicate the entry.
+		const rederived = buildEndpointParametersSchema(result, 'inputSchema');
+		const rederivedRequired = definitionsOf(rederived).parameter.required as string[];
+		assert.strictEqual(rederivedRequired.filter((entry) => entry === 'help').length, 1);
+	});
+
+	test('removes `banner` from the type enum and strips banner-only properties, keeps others', () => {
+		const result = buildEndpointParametersSchema(parametersSchema, 'inputSchema');
+		const parameter = definitionsOf(result).parameter;
+		const properties = parameter.properties as Record<string, unknown>;
+		const typeEnum = (properties.type as { oneOf: { enum?: string[] }[] }).oneOf[0].enum as string[];
+
+		assert.ok(!typeEnum.includes('banner'));
+		assert.ok(typeEnum.includes('text'), 'unrelated type values are preserved');
+
+		for (const bannerProp of ['title', 'text', 'closable', 'theme', 'badge']) {
+			assert.ok(!(bannerProp in properties), `"${bannerProp}" should be removed`);
+		}
+		for (const keptProp of ['name', 'label', 'help', 'type', 'default', 'required']) {
+			assert.ok(keptProp in properties, `"${keptProp}" should be kept`);
+		}
+	});
+
+	test('wires namedParameter/topLevelParameter into `parameters.items` and the root `items`', () => {
+		const result = buildEndpointParametersSchema(parametersSchema, 'inputSchema');
+		const definitions = definitionsOf(result);
+
+		assert.deepStrictEqual(definitions.namedParameter, {
+			allOf: [{ $ref: '#/definitions/parameter' }, { required: ['name'] }],
+		});
+		assert.deepStrictEqual(definitions.parameters.items, { $ref: '#/definitions/namedParameter' });
+		assert.deepStrictEqual(result.items, { $ref: '#/definitions/topLevelParameter' });
+
+		const topLevelParameter = definitions.topLevelParameter as { allOf: unknown[] };
+		assert.deepStrictEqual(topLevelParameter.allOf[0], { $ref: '#/definitions/namedParameter' });
+	});
+
+	test('constrains a top-level `json` field name to the given jsonFieldName', () => {
+		const input = buildEndpointParametersSchema(parametersSchema, 'inputSchema');
+		const output = buildEndpointParametersSchema(parametersSchema, 'outputSchema');
+
+		const inputThen = (definitionsOf(input).topLevelParameter as { allOf: { then?: unknown }[] }).allOf[1].then;
+		const outputThen = (definitionsOf(output).topLevelParameter as { allOf: { then?: unknown }[] }).allOf[1].then;
+
+		assert.deepStrictEqual(inputThen, { properties: { name: { const: 'inputSchema' } } });
+		assert.deepStrictEqual(outputThen, { properties: { name: { const: 'outputSchema' } } });
+	});
+
+	test('removes every definition\'s `$id`', () => {
+		const result = buildEndpointParametersSchema(parametersSchema, 'inputSchema');
+		for (const [name, definition] of Object.entries(definitionsOf(result))) {
+			assert.ok(!('$id' in definition), `definitions.${name} should not carry an $id`);
+		}
+	});
+
+	test('does not mutate the input schema', () => {
+		const before = JSON.parse(JSON.stringify(parametersSchema));
+		buildEndpointParametersSchema(parametersSchema, 'inputSchema');
+		assert.deepStrictEqual(parametersSchema, before);
+	});
+});

--- a/src/services/endpoint-parameters-schema.test.ts
+++ b/src/services/endpoint-parameters-schema.test.ts
@@ -70,7 +70,7 @@ suite('buildEndpointParametersSchema()', () => {
 		assert.deepStrictEqual(outputThen, { properties: { name: { const: 'outputSchema' } } });
 	});
 
-	test('removes every definition\'s `$id`', () => {
+	test("removes every definition's `$id`", () => {
 		const result = buildEndpointParametersSchema(parametersSchema, 'inputSchema');
 		for (const [name, definition] of Object.entries(definitionsOf(result))) {
 			assert.ok(!('$id' in definition), `definitions.${name} should not carry an $id`);

--- a/src/services/endpoint-parameters-schema.ts
+++ b/src/services/endpoint-parameters-schema.ts
@@ -1,0 +1,72 @@
+/**
+ * Endpoint Input/Output parameters are consumed by AI agents, so every parameter (at every nesting
+ * level) must carry a `help` description and a `name`, the purely-visual `banner` type isn't offered
+ * here, and a top-level `json` field must use the canonical name for its tab.
+ *
+ * Rather than duplicate the large `parameters.json`, this derives an endpoint-scoped variant from it:
+ * - `help` is added to the shared `parameter` definition's `required` list — all nested parameters
+ *   reference that same definition, so the rule applies recursively.
+ * - `banner` is removed from the allowed `type` values (a literal `"banner"` can't slip through the
+ *   IML-string branch, which requires `{{ }}`).
+ * - `name` is required on every *named* parameter (top-level fields and object/collection properties),
+ *   because a nameless field is silently dropped from the generated object schema. Array item specs
+ *   describe the item type rather than a named property, so they keep using the base `parameter`.
+ * - A *top-level* `json` field must be named `jsonFieldName` (`inputSchema`/`outputSchema`), so the
+ *   exposed schema is consistent. Scoped to the top level so multiple/nested `json` fields (which
+ *   would collide on the same name) aren't forced.
+ *
+ * Ported from imt-web-zone's `apps-edit-monaco-iml.service.ts` (`buildEndpointParametersSchema`).
+ *
+ * @param parametersSchema - The parsed `syntaxes/imljson/schemas/parameters.json` content. Not mutated.
+ * @param jsonFieldName - The canonical name a top-level `json`-type parameter must use.
+ * @returns A deep-copied, endpoint-scoped variant of `parametersSchema`.
+ */
+export function buildEndpointParametersSchema(
+	parametersSchema: Record<string, unknown>,
+	jsonFieldName: 'inputSchema' | 'outputSchema',
+): Record<string, unknown> {
+	const schema = JSON.parse(JSON.stringify(parametersSchema)) as Record<string, unknown>;
+	const definitions = schema.definitions as Record<string, Record<string, unknown>>;
+	const parameter = definitions.parameter;
+
+	const parameterRequired = parameter.required as string[];
+	if (!parameterRequired.includes('help')) {
+		parameter.required = [...parameterRequired, 'help'];
+	}
+
+	const parameterProperties = parameter.properties as Record<string, Record<string, unknown>>;
+	const typeOneOf = parameterProperties.type.oneOf as { enum?: string[] }[];
+	typeOneOf[0].enum = (typeOneOf[0].enum as string[]).filter((type) => type !== 'banner');
+	const bannerProps = new Set(['title', 'text', 'closable', 'theme', 'badge']);
+	parameter.properties = Object.fromEntries(
+		Object.entries(parameterProperties).filter(([propName]) => !bannerProps.has(propName)),
+	);
+
+	// A named parameter requires `name`. Point the nested "named" contexts at it: the `parameters`
+	// array (collection properties, nested fields, rpc form fields). Array item specs still reference
+	// the base `parameter` (no name needed).
+	definitions.namedParameter = {
+		allOf: [{ $ref: '#/definitions/parameter' }, { required: ['name'] }],
+	};
+	definitions.parameters.items = { $ref: '#/definitions/namedParameter' };
+
+	// A top-level parameter is a named parameter that, when it's a `json` field, must use the tab's
+	// canonical name. Only the top-level `items` reference it, so nested `json` fields are unaffected.
+	definitions.topLevelParameter = {
+		allOf: [
+			{ $ref: '#/definitions/namedParameter' },
+			{
+				if: { properties: { type: { const: 'json' } }, required: ['type'] },
+				then: { properties: { name: { const: jsonFieldName } } },
+			},
+		],
+	};
+	schema.items = { $ref: '#/definitions/topLevelParameter' };
+
+	// Drop per-definition `$id`s so these fragments don't collide with the shared parameters.json schema.
+	for (const definition of Object.values(definitions)) {
+		delete definition.$id;
+	}
+
+	return schema;
+}

--- a/src/services/endpoint-schema-validation.test.ts
+++ b/src/services/endpoint-schema-validation.test.ts
@@ -9,7 +9,7 @@ import {
 	type LanguageService,
 	type SchemaConfiguration,
 } from 'vscode-json-languageservice';
-import { enrichApiSchemaWithEndpoints } from './endpoint-api-enrichment';
+import { enrichApiSchemaWithEndpoints, extractEndpointInputParameters } from './endpoint-api-enrichment';
 import { getStaticAndDerivedSchemaAssociations } from './imljson-schema-associations';
 
 /**
@@ -203,16 +203,57 @@ suite('Endpoint IMLJSON schema validation (fixtures) — online-mode enrichment'
 	// class builds it), so its relative `sources.json#/...` refs still resolve to real files on disk.
 	const schemasDir = path.join(__dirname, '../../syntaxes/imljson/schemas');
 	const apiSchema = JSON.parse(readFileSync(path.join(schemasDir, 'api.json'), 'utf8')) as Record<string, unknown>;
+	// Endpoints built via `extractEndpointInputParameters` from realistic *raw* API-shaped
+	// `inputParameters` (not hand-built `EndpointInputParameter[]`), so these fixtures exercise the real
+	// extraction → suggestion-entry → completion pipeline end to end for all three shapes.
+	const endpoints = [
+		{
+			name: 'list-things',
+			inputParameters: extractEndpointInputParameters([{ name: 'page', label: 'Page number', type: 'integer' }]),
+		},
+		{
+			name: 'list-things-json',
+			inputParameters: extractEndpointInputParameters([
+				{
+					name: 'inputSchema',
+					type: 'json',
+					schema: {
+						type: 'object',
+						properties: { id: { type: 'integer', description: 'Thing id' } },
+						required: ['id'],
+					},
+				},
+			]),
+		},
+		{
+			name: 'list-things-mixed',
+			inputParameters: extractEndpointInputParameters([
+				{ name: 'page', label: 'Page number', type: 'integer' },
+				{
+					name: 'inputSchema',
+					type: 'json',
+					schema: { type: 'object', properties: { qty: { type: 'integer' } } },
+				},
+			]),
+		},
+	];
 	const enrichedEntry: SchemaConfiguration = {
 		uri: pathToFileURL(path.join(schemasDir, 'api-enriched--demo-app--v2.json')).toString(),
 		fileMatch: ['api.imljson', 'publish.imljson', 'attach.imljson', 'detach.imljson'].map(
 			(basename) => `**/apps-sdk/**/demo-app/2/**/${basename}`,
 		),
-		schema: enrichApiSchemaWithEndpoints(apiSchema, [
-			{ name: 'list-things', inputParameters: [{ name: 'page', description: 'Page number' }] },
-		]),
+		schema: enrichApiSchemaWithEndpoints(apiSchema, endpoints),
 	};
 	const languageService = buildLanguageService([...getStaticAndDerivedSchemaAssociations(), enrichedEntry]);
+
+	async function inputCompletionLabels(endpointName: string): Promise<(string | undefined)[]> {
+		const content = `{"endpoint":"${endpointName}","input":{}}`;
+		const document = TextDocument.create(MODULE_URI, 'imljson', 1, content);
+		const jsonDocument = languageService.parseJSONDocument(document);
+		const position = document.positionAt(content.indexOf('"input":{') + '"input":{'.length);
+		const completions = await languageService.doComplete(document, position, jsonDocument);
+		return (completions?.items ?? []).map((item) => item.label);
+	}
 
 	test('19. module (enriched app/version): known endpoint name → OK', async () => {
 		const messages = await validate(languageService, MODULE_URI, '{"endpoint":"list-things"}');
@@ -235,15 +276,29 @@ suite('Endpoint IMLJSON schema validation (fixtures) — online-mode enrichment'
 	});
 
 	test("23. module (enriched app/version): input-suggestion entries offer the endpoint's parameter keys", async () => {
-		const content = '{"endpoint":"list-things","input":{}}';
-		const document = TextDocument.create(MODULE_URI, 'imljson', 1, content);
-		const jsonDocument = languageService.parseJSONDocument(document);
-		const position = document.positionAt(content.indexOf('"input":{') + '"input":{'.length);
+		assert.deepStrictEqual(await inputCompletionLabels('list-things'), ['page']);
+	});
 
-		const completions = await languageService.doComplete(document, position, jsonDocument);
-		assert.ok(
-			completions?.items.some((item) => item.label === 'page'),
-			`Expected a "page" completion, got: ${JSON.stringify(completions?.items.map((item) => item.label))}`,
+	test('24. module (JSON-Schema-wrapped endpoint): input-suggestions are the unwrapped properties, not the wrapper name', async () => {
+		assert.deepStrictEqual(await inputCompletionLabels('list-things-json'), ['id']);
+	});
+
+	test('25. module (mixed form-field + JSON-Schema endpoint): input-suggestions include both', async () => {
+		assert.deepStrictEqual(await inputCompletionLabels('list-things-mixed'), ['page', 'qty']);
+	});
+
+	test('26. module (JSON-Schema-wrapped endpoint): suggestions do not leak across endpoints, and an unknown/missing key is still not an error', async () => {
+		// Referencing one endpoint must not offer another's keys.
+		const jsonLabels = await inputCompletionLabels('list-things-json');
+		assert.ok(!jsonLabels.includes('page') && !jsonLabels.includes('qty'));
+
+		// Suggestion-only: an unrecognized key, or a missing one the wrapped schema marked `required`,
+		// is never flagged — this is completion, not validation.
+		const messages = await validate(
+			languageService,
+			MODULE_URI,
+			'{"endpoint":"list-things-json","input":{"somethingElse":1}}',
 		);
+		assert.deepStrictEqual(messages, []);
 	});
 });

--- a/src/services/endpoint-schema-validation.test.ts
+++ b/src/services/endpoint-schema-validation.test.ts
@@ -3,7 +3,12 @@ import { promises as fs, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { suite, test } from 'mocha';
-import { getLanguageService, TextDocument, type LanguageService, type SchemaConfiguration } from 'vscode-json-languageservice';
+import {
+	getLanguageService,
+	TextDocument,
+	type LanguageService,
+	type SchemaConfiguration,
+} from 'vscode-json-languageservice';
 import { enrichApiSchemaWithEndpoints } from './endpoint-api-enrichment';
 import { getStaticAndDerivedSchemaAssociations } from './imljson-schema-associations';
 
@@ -229,7 +234,7 @@ suite('Endpoint IMLJSON schema validation (fixtures) — online-mode enrichment'
 		assert.deepStrictEqual(messages, []);
 	});
 
-	test('23. module (enriched app/version): input-suggestion entries offer the endpoint\'s parameter keys', async () => {
+	test("23. module (enriched app/version): input-suggestion entries offer the endpoint's parameter keys", async () => {
 		const content = '{"endpoint":"list-things","input":{}}';
 		const document = TextDocument.create(MODULE_URI, 'imljson', 1, content);
 		const jsonDocument = languageService.parseJSONDocument(document);

--- a/src/services/endpoint-schema-validation.test.ts
+++ b/src/services/endpoint-schema-validation.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { suite, test } from 'mocha';
 import { getLanguageService, TextDocument, type LanguageService, type SchemaConfiguration } from 'vscode-json-languageservice';
-import { getJsonSchemas } from '../LanguageServersSettings';
+import { getStaticAndDerivedSchemaAssociations } from './imljson-schema-associations';
 
 /**
  * Fixture suite validating IMLJSON api/base files against the real schemas in
@@ -15,6 +15,8 @@ const MODULE_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/modules/get-things/ap
 const ENDPOINT_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/endpoints/list-things/api.imljson';
 const LOCAL_ENDPOINT_URI = 'file:///w/src/endpoints/list-things/list-things.communication.iml.json';
 const BASE_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/base.imljson';
+const INPUT_PARAMS_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/endpoints/list-things/inputParameters.imljson';
+const OUTPUT_PARAMS_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/endpoints/list-things/outputParameters.imljson';
 
 function resolveRelativePath(relativePath: string, resource: string): string {
 	return new URL(relativePath, resource).toString();
@@ -41,7 +43,7 @@ async function validate(languageService: LanguageService, uri: string, content: 
 }
 
 suite('Endpoint IMLJSON schema validation (fixtures)', () => {
-	const languageService = buildLanguageService(getJsonSchemas());
+	const languageService = buildLanguageService(getStaticAndDerivedSchemaAssociations());
 
 	test('1. module: endpoint object form + response → OK', async () => {
 		const messages = await validate(languageService, MODULE_URI, '{"endpoint":{"name":"x"},"response":{}}');
@@ -116,6 +118,66 @@ suite('Endpoint IMLJSON schema validation (fixtures)', () => {
 
 		const localMessages = await validate(languageService, LOCAL_ENDPOINT_URI, '{"url":"/things","method":"GET"}');
 		assert.deepStrictEqual(localMessages, []);
+	});
+
+	test('12. inputParameters.imljson: parameter missing `help` → error', async () => {
+		const messages = await validate(languageService, INPUT_PARAMS_URI, '[{"name":"foo","type":"text"}]');
+		assert.deepStrictEqual(messages, ['Missing property "help".']);
+	});
+
+	test('13. inputParameters.imljson: parameter missing `name` → error', async () => {
+		const messages = await validate(languageService, INPUT_PARAMS_URI, '[{"type":"text","help":"h"}]');
+		assert.deepStrictEqual(messages, ['Missing property "name".']);
+	});
+
+	test('14. inputParameters.imljson: `banner` type is rejected', async () => {
+		const messages = await validate(
+			languageService,
+			INPUT_PARAMS_URI,
+			'[{"name":"foo","type":"banner","help":"h"}]',
+		);
+		assert.ok(messages.length > 0, 'Expected the banner type to be rejected.');
+	});
+
+	test('15. inputParameters.imljson: top-level `json` field must be named "inputSchema"', async () => {
+		const okMessages = await validate(
+			languageService,
+			INPUT_PARAMS_URI,
+			'[{"name":"inputSchema","type":"json","help":"h"}]',
+		);
+		assert.deepStrictEqual(okMessages, []);
+
+		const errorMessages = await validate(
+			languageService,
+			INPUT_PARAMS_URI,
+			'[{"name":"result","type":"json","help":"h"}]',
+		);
+		assert.ok(errorMessages.length > 0, 'Expected a mismatched top-level json name to be rejected.');
+	});
+
+	test('16. outputParameters.imljson: top-level `json` field must be named "outputSchema"', async () => {
+		const okMessages = await validate(
+			languageService,
+			OUTPUT_PARAMS_URI,
+			'[{"name":"outputSchema","type":"json","help":"h"}]',
+		);
+		assert.deepStrictEqual(okMessages, []);
+
+		const errorMessages = await validate(
+			languageService,
+			OUTPUT_PARAMS_URI,
+			'[{"name":"result","type":"json","help":"h"}]',
+		);
+		assert.ok(errorMessages.length > 0, 'Expected a mismatched top-level json name to be rejected.');
+	});
+
+	test('17. inputParameters.imljson: nested parameter missing `help` → error (recursion)', async () => {
+		const messages = await validate(
+			languageService,
+			INPUT_PARAMS_URI,
+			'[{"name":"parent","type":"collection","help":"h","nested":[{"name":"child","type":"text"}]}]',
+		);
+		assert.deepStrictEqual(messages, ['Missing property "help".']);
 	});
 
 	test('18. base.imljson: timeout within bounds → OK, over the maximum → error', async () => {

--- a/src/services/endpoint-schema-validation.test.ts
+++ b/src/services/endpoint-schema-validation.test.ts
@@ -1,0 +1,128 @@
+import * as assert from 'node:assert';
+import { promises as fs } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { suite, test } from 'mocha';
+import { getLanguageService, TextDocument, type LanguageService, type SchemaConfiguration } from 'vscode-json-languageservice';
+import { getJsonSchemas } from '../LanguageServersSettings';
+
+/**
+ * Fixture suite validating IMLJSON api/base files against the real schemas in
+ * `syntaxes/imljson/schemas/`, using the same JSON schema engine (5.7.2) as the vendored
+ * language server, configured with the production schema association list.
+ */
+
+const MODULE_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/modules/get-things/api.imljson';
+const ENDPOINT_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/endpoints/list-things/api.imljson';
+const LOCAL_ENDPOINT_URI = 'file:///w/src/endpoints/list-things/list-things.communication.iml.json';
+const BASE_URI = 'file:///t/apps-sdk/sdk/apps/demo-app/2/base.imljson';
+
+function resolveRelativePath(relativePath: string, resource: string): string {
+	return new URL(relativePath, resource).toString();
+}
+
+async function schemaRequestService(uri: string): Promise<string> {
+	return fs.readFile(fileURLToPath(uri), 'utf8');
+}
+
+function buildLanguageService(schemas: SchemaConfiguration[]): LanguageService {
+	const languageService = getLanguageService({ schemaRequestService, workspaceContext: { resolveRelativePath } });
+	languageService.configure({ validate: true, allowComments: true, schemas });
+	return languageService;
+}
+
+async function validate(languageService: LanguageService, uri: string, content: string): Promise<string[]> {
+	const document = TextDocument.create(uri, 'imljson', 1, content);
+	const jsonDocument = languageService.parseJSONDocument(document);
+	const diagnostics = await languageService.doValidation(document, jsonDocument, {
+		comments: 'ignore',
+		trailingCommas: 'warning',
+	});
+	return diagnostics.map((diagnostic) => diagnostic.message);
+}
+
+suite('Endpoint IMLJSON schema validation (fixtures)', () => {
+	const languageService = buildLanguageService(getJsonSchemas());
+
+	test('1. module: endpoint object form + response → OK', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"endpoint":{"name":"x"},"response":{}}');
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('2. module: endpoint shorthand string form → OK', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"endpoint":"x"}');
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('3. module: input without endpoint → dependency error', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"input":{},"url":"/x"}');
+		assert.deepStrictEqual(messages, ['Object is missing property endpoint required by property input.']);
+	});
+
+	test('4. module: endpoint with url/method → banned-directive errorMessage', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"endpoint":"x","url":"/y","method":"GET"}');
+		assert.ok(messages.length > 0);
+		for (const message of messages) {
+			assert.strictEqual(
+				message,
+				"Not allowed when 'endpoint' is present — the request runs a sibling Endpoint instead of an HTTP request.",
+			);
+		}
+	});
+
+	test('5. module: valid endpointPagination → OK', async () => {
+		const messages = await validate(
+			languageService,
+			MODULE_URI,
+			'{"endpoint":"x","pagination":{"endpoint":"y","mergeWithParent":true,"input":{}}}',
+		);
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('6. module: classic pagination.url with endpoint present → error', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"endpoint":"x","pagination":{"url":"/next"}}');
+		assert.deepStrictEqual(messages, ['Property url is not allowed.']);
+	});
+
+	test('7. module: plain HTTP request → OK', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"url":"/things","method":"GET"}');
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('8. module: array of requests → OK', async () => {
+		const messages = await validate(
+			languageService,
+			MODULE_URI,
+			'[{"url":"/a","method":"GET"},{"url":"/b","method":"GET"}]',
+		);
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('9. endpoint api.imljson: endpoint directive → error (combined match)', async () => {
+		const messages = await validate(languageService, ENDPOINT_URI, '{"endpoint":"x"}');
+		assert.ok(
+			messages.includes('Matches a schema that is not allowed.'),
+			`Expected a "not allowed" error, got: ${JSON.stringify(messages)}`,
+		);
+	});
+
+	test('10. endpoint api.imljson: array form → error', async () => {
+		const messages = await validate(languageService, ENDPOINT_URI, '[{"url":"/a","method":"GET"}]');
+		assert.ok(messages.length > 0, 'Expected the array-root form to be rejected for an Endpoint api file.');
+	});
+
+	test('11. plain HTTP request at endpoint (online + local-dev) URIs → OK', async () => {
+		const onlineMessages = await validate(languageService, ENDPOINT_URI, '{"url":"/things","method":"GET"}');
+		assert.deepStrictEqual(onlineMessages, []);
+
+		const localMessages = await validate(languageService, LOCAL_ENDPOINT_URI, '{"url":"/things","method":"GET"}');
+		assert.deepStrictEqual(localMessages, []);
+	});
+
+	test('18. base.imljson: timeout within bounds → OK, over the maximum → error', async () => {
+		const okMessages = await validate(languageService, BASE_URI, '{"timeout":30000}');
+		assert.deepStrictEqual(okMessages, []);
+
+		const errorMessages = await validate(languageService, BASE_URI, '{"timeout":400000}');
+		assert.deepStrictEqual(errorMessages, ['Value is above the maximum of 300000.']);
+	});
+});

--- a/src/services/endpoint-schema-validation.test.ts
+++ b/src/services/endpoint-schema-validation.test.ts
@@ -236,6 +236,24 @@ suite('Endpoint IMLJSON schema validation (fixtures) — online-mode enrichment'
 				},
 			]),
 		},
+		{
+			name: 'list-things-nested',
+			inputParameters: extractEndpointInputParameters([
+				{
+					name: 'inputSchema',
+					type: 'json',
+					schema: {
+						type: 'object',
+						properties: {
+							address: {
+								type: 'object',
+								properties: { city: { type: 'string', description: 'City name' } },
+							},
+						},
+					},
+				},
+			]),
+		},
 	];
 	const enrichedEntry: SchemaConfiguration = {
 		uri: pathToFileURL(path.join(schemasDir, 'api-enriched--demo-app--v2.json')).toString(),
@@ -251,6 +269,19 @@ suite('Endpoint IMLJSON schema validation (fixtures) — online-mode enrichment'
 		const document = TextDocument.create(MODULE_URI, 'imljson', 1, content);
 		const jsonDocument = languageService.parseJSONDocument(document);
 		const position = document.positionAt(content.indexOf('"input":{') + '"input":{'.length);
+		const completions = await languageService.doComplete(document, position, jsonDocument);
+		return (completions?.items ?? []).map((item) => item.label);
+	}
+
+	async function nestedInputCompletionLabels(
+		endpointName: string,
+		parentKey: string,
+	): Promise<(string | undefined)[]> {
+		const content = `{"endpoint":"${endpointName}","input":{"${parentKey}":{}}}`;
+		const document = TextDocument.create(MODULE_URI, 'imljson', 1, content);
+		const jsonDocument = languageService.parseJSONDocument(document);
+		const marker = `"${parentKey}":{`;
+		const position = document.positionAt(content.indexOf(marker) + marker.length);
 		const completions = await languageService.doComplete(document, position, jsonDocument);
 		return (completions?.items ?? []).map((item) => item.label);
 	}
@@ -300,5 +331,10 @@ suite('Endpoint IMLJSON schema validation (fixtures) — online-mode enrichment'
 			'{"endpoint":"list-things-json","input":{"somethingElse":1}}',
 		);
 		assert.deepStrictEqual(messages, []);
+	});
+
+	test('27. module (nested-collection endpoint): completing inside input.<parent>.{} offers the nested sub-key', async () => {
+		assert.deepStrictEqual(await inputCompletionLabels('list-things-nested'), ['address']);
+		assert.deepStrictEqual(await nestedInputCompletionLabels('list-things-nested', 'address'), ['city']);
 	});
 });

--- a/src/services/endpoint-schema-validation.test.ts
+++ b/src/services/endpoint-schema-validation.test.ts
@@ -1,8 +1,10 @@
 import * as assert from 'node:assert';
-import { promises as fs } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { promises as fs, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { suite, test } from 'mocha';
 import { getLanguageService, TextDocument, type LanguageService, type SchemaConfiguration } from 'vscode-json-languageservice';
+import { enrichApiSchemaWithEndpoints } from './endpoint-api-enrichment';
 import { getStaticAndDerivedSchemaAssociations } from './imljson-schema-associations';
 
 /**
@@ -186,5 +188,57 @@ suite('Endpoint IMLJSON schema validation (fixtures)', () => {
 
 		const errorMessages = await validate(languageService, BASE_URI, '{"timeout":400000}');
 		assert.deepStrictEqual(errorMessages, ['Value is above the maximum of 300000.']);
+	});
+});
+
+suite('Endpoint IMLJSON schema validation (fixtures) — online-mode enrichment', () => {
+	const OTHER_APP_URI = 'file:///t/apps-sdk/sdk/apps/other-app/3/modules/get-others/api.imljson';
+
+	// The enriched entry's URI must be a flat sibling of the real schema files (like the production
+	// class builds it), so its relative `sources.json#/...` refs still resolve to real files on disk.
+	const schemasDir = path.join(__dirname, '../../syntaxes/imljson/schemas');
+	const apiSchema = JSON.parse(readFileSync(path.join(schemasDir, 'api.json'), 'utf8')) as Record<string, unknown>;
+	const enrichedEntry: SchemaConfiguration = {
+		uri: pathToFileURL(path.join(schemasDir, 'api-enriched--demo-app--v2.json')).toString(),
+		fileMatch: ['api.imljson', 'publish.imljson', 'attach.imljson', 'detach.imljson'].map(
+			(basename) => `**/apps-sdk/**/demo-app/2/**/${basename}`,
+		),
+		schema: enrichApiSchemaWithEndpoints(apiSchema, [
+			{ name: 'list-things', inputParameters: [{ name: 'page', description: 'Page number' }] },
+		]),
+	};
+	const languageService = buildLanguageService([...getStaticAndDerivedSchemaAssociations(), enrichedEntry]);
+
+	test('19. module (enriched app/version): known endpoint name → OK', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"endpoint":"list-things"}');
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('20. module (enriched app/version): unknown endpoint name → enum error', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"endpoint":"unknown-thing"}');
+		assert.ok(messages.length > 0, 'Expected an unknown endpoint name to be rejected.');
+	});
+
+	test('21. module (enriched app/version): `{{iml}}` endpoint name → OK', async () => {
+		const messages = await validate(languageService, MODULE_URI, '{"endpoint":"{{iml}}"}');
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('22. module (different app/version): unknown endpoint name → NO enum error (glob scoping)', async () => {
+		const messages = await validate(languageService, OTHER_APP_URI, '{"endpoint":"unknown-thing"}');
+		assert.deepStrictEqual(messages, []);
+	});
+
+	test('23. module (enriched app/version): input-suggestion entries offer the endpoint\'s parameter keys', async () => {
+		const content = '{"endpoint":"list-things","input":{}}';
+		const document = TextDocument.create(MODULE_URI, 'imljson', 1, content);
+		const jsonDocument = languageService.parseJSONDocument(document);
+		const position = document.positionAt(content.indexOf('"input":{') + '"input":{'.length);
+
+		const completions = await languageService.doComplete(document, position, jsonDocument);
+		assert.ok(
+			completions?.items.some((item) => item.label === 'page'),
+			`Expected a "page" completion, got: ${JSON.stringify(completions?.items.map((item) => item.label))}`,
+		);
 	});
 });

--- a/src/services/imljson-schema-associations.test.ts
+++ b/src/services/imljson-schema-associations.test.ts
@@ -1,0 +1,71 @@
+import * as assert from 'node:assert';
+import { suite, test } from 'mocha';
+import proxyquire from 'proxyquire';
+import type * as vscode from 'vscode';
+
+/**
+ * Regression coverage for the app-major-version vs. API-version mixup: `Core.pathDeterminer` must be
+ * called with the *API* version (always 2 here, per the `environment.version !== 2` guard), not the
+ * app's own major version parsed out of the temp file path — otherwise the fetch URL degenerates to the
+ * v1 shape for any app whose major version isn't coincidentally 2 (e.g. every version-1 app).
+ */
+function loadModuleWithMockedCore(rpGet: (url: string, ...rest: unknown[]) => Promise<unknown>) {
+	return proxyquire('./imljson-schema-associations', {
+		'../Core': { rpGet },
+	}) as typeof import('./imljson-schema-associations');
+}
+
+function createEditorForFile(fileName: string): vscode.TextEditor {
+	return { document: { fileName } } as unknown as vscode.TextEditor;
+}
+
+suite('ImljsonSchemaAssociations', () => {
+	test("fetches endpoints using the API version, not the app's own major version", async () => {
+		let requestedUrl: string | undefined;
+		const mod = loadModuleWithMockedCore(async (url: string) => {
+			requestedUrl = url;
+			return { appEndpoints: [{ name: 'list-things' }] };
+		});
+
+		const sentNotifications: unknown[] = [];
+		const associations = new mod.ImljsonSchemaAssociations({
+			client: {
+				sendNotification: async (_type: unknown, payload: unknown) => sentNotifications.push(payload),
+			} as any,
+			authorization: 'Token test',
+			// The app in the file path below is major version 1 — a real app on API v2 whose own
+			// version number happens to differ from the API version (the bug's exact failure case).
+			environment: { baseUrl: 'https://example.make.com/v2', version: 2 },
+		});
+
+		await associations.handleActiveEditorChange(
+			createEditorForFile('/tmp/xyz/apps-sdk/sdk/apps/demo-app/1/modules/get-things/api.imljson'),
+		);
+
+		assert.strictEqual(requestedUrl, 'https://example.make.com/v2/sdk/apps/demo-app/1/endpoints');
+		assert.strictEqual(sentNotifications.length, 1);
+	});
+
+	test('never fetches for a connection/webhook api.imljson (no version segment in its temp path)', async () => {
+		let fetchCalled = false;
+		const mod = loadModuleWithMockedCore(async () => {
+			fetchCalled = true;
+			return { appEndpoints: [] };
+		});
+
+		const associations = new mod.ImljsonSchemaAssociations({
+			client: { sendNotification: async () => undefined } as any,
+			authorization: 'Token test',
+			environment: { baseUrl: 'https://example.make.com/v2', version: 2 },
+		});
+
+		// Connections/webhooks are non-versionable (`Core.isVersionable`), so their temp paths have no
+		// numeric version segment — `parseAppAndVersion` must reject this rather than misreading
+		// "connections" as the app's version.
+		await associations.handleActiveEditorChange(
+			createEditorForFile('/tmp/xyz/apps-sdk/sdk/apps/demo-app/connections/my-conn/api.imljson'),
+		);
+
+		assert.strictEqual(fetchCalled, false);
+	});
+});

--- a/src/services/imljson-schema-associations.ts
+++ b/src/services/imljson-schema-associations.ts
@@ -2,8 +2,13 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { SchemaConfiguration } from 'vscode-json-languageservice';
-import { NotificationType } from 'vscode-languageclient/node';
+import { NotificationType, type LanguageClient } from 'vscode-languageclient/node';
+import * as Core from '../Core';
+import { log } from '../output-channel';
+import { isFileBelongingToExtension } from '../temp-dir';
+import type { Environment } from '../types/environment.types';
 import * as LanguageServersSettings from '../LanguageServersSettings';
+import { enrichApiSchemaWithEndpoints, extractEndpointInputParameters, type SdkEndpointSchemaInfo } from './endpoint-api-enrichment';
 import { buildEndpointParametersSchema } from './endpoint-parameters-schema';
 
 /**
@@ -14,15 +19,33 @@ export const schemaAssociationsNotificationType = new NotificationType<SchemaCon
 	'imljson/schemaAssociations',
 );
 
+/**
+ * Basenames whose api schema is eligible for online-mode Endpoint enrichment (see
+ * {@link ImljsonSchemaAssociations}) — the files whose `endpoint`/`pagination.endpoint` directives
+ * reference a sibling Endpoint by name.
+ */
+const ENRICHABLE_BASENAMES = ['api.imljson', 'publish.imljson', 'attach.imljson', 'detach.imljson'];
+
+/** How long a fetched (or failed) app/version entry is considered fresh, in milliseconds. */
+const ENRICHMENT_CACHE_TTL_MS = 60_000;
+
 let parametersSchemaCache: Record<string, unknown> | undefined;
+let apiSchemaCache: Record<string, unknown> | undefined;
+
+/**
+ * Absolute path of the extension's real `syntaxes/imljson/schemas/` directory.
+ */
+function schemasDir(): string {
+	const extension = vscode.extensions.getExtension('Integromat.apps-sdk')!;
+	return path.join(extension.extensionPath, 'syntaxes', 'imljson', 'schemas');
+}
 
 /**
  * Absolute `file://` URI of a schema file living next to the real ones in
  * `syntaxes/imljson/schemas/`, resolved the same way as `LanguageServersSettings.getJsonSchemas()`.
  */
 function schemaFileUri(filename: string): string {
-	const extension = vscode.extensions.getExtension('Integromat.apps-sdk')!;
-	return vscode.Uri.file(path.join(extension.extensionPath, 'syntaxes', 'imljson', 'schemas', filename)).toString();
+	return vscode.Uri.file(path.join(schemasDir(), filename)).toString();
 }
 
 /**
@@ -31,17 +54,26 @@ function schemaFileUri(filename: string): string {
  */
 function getParametersSchema(): Record<string, unknown> {
 	if (!parametersSchemaCache) {
-		const extension = vscode.extensions.getExtension('Integromat.apps-sdk')!;
-		const parametersSchemaPath = path.join(
-			extension.extensionPath,
-			'syntaxes',
-			'imljson',
-			'schemas',
-			'parameters.json',
-		);
-		parametersSchemaCache = JSON.parse(fs.readFileSync(parametersSchemaPath, 'utf8')) as Record<string, unknown>;
+		parametersSchemaCache = JSON.parse(fs.readFileSync(path.join(schemasDir(), 'parameters.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
 	}
 	return parametersSchemaCache;
+}
+
+/**
+ * Reads and parses `syntaxes/imljson/schemas/api.json` once, lazily, from the extension's own install
+ * path.
+ */
+function getApiSchema(): Record<string, unknown> {
+	if (!apiSchemaCache) {
+		apiSchemaCache = JSON.parse(fs.readFileSync(path.join(schemasDir(), 'api.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+	}
+	return apiSchemaCache;
 }
 
 /**
@@ -67,4 +99,160 @@ export function getStaticAndDerivedSchemaAssociations(): SchemaConfiguration[] {
 			schema: buildEndpointParametersSchema(parametersSchema, 'outputSchema'),
 		},
 	];
+}
+
+/**
+ * Parses `{app, version}` out of a temp-dir file name the same way `CoreCommands.keepProviders` does:
+ * the segment after `apps-sdk` is `/sdk/apps/{app}/{version}/...`; `sdk` is a fixed crumb that gets
+ * shifted off, leaving `app` at index 2 and `version` at index 3. Connection/webhook files have no
+ * version segment (index 3 isn't numeric) and are intentionally dropped — they're never enriched.
+ */
+function parseAppAndVersion(fileName: string): { app: string; version: number } | null {
+	const afterPrefix = fileName.split('apps-sdk')[1];
+	if (!afterPrefix) {
+		return null;
+	}
+
+	const crumbs = afterPrefix.replace(/\\/g, '/').split('/');
+	if (crumbs[1] === 'sdk') {
+		crumbs.shift();
+	}
+
+	const app = crumbs[2];
+	const version = Number(crumbs[3]);
+	if (!app || Number.isNaN(version)) {
+		return null;
+	}
+	return { app, version };
+}
+
+interface EnrichmentCacheEntry {
+	entry?: SchemaConfiguration;
+	fetchedAt: number;
+}
+
+export interface ImljsonSchemaAssociationsDependencies {
+	client: LanguageClient;
+	authorization: string;
+	environment: Environment;
+}
+
+/**
+ * Online-mode-only: enriches the `api.json` schema, per app+version, with that app's actual Endpoint
+ * names (so `endpoint`/`pagination.endpoint` validate against — and autocomplete from — real endpoints)
+ * and per-endpoint Input Parameter suggestions. Ported from imt-web-zone's
+ * `ImlLanguage.getSchemasWithEndpoints` / `buildInputSuggestionEntries`, adapted to this extension's
+ * push-based (not on-demand) schema association model.
+ *
+ * Never throws and never shows a dialog — enrichment is a nice-to-have; failures silently fall back to
+ * the static/derived schemas (free-string endpoint name), logged at 'debug'/'warn' via the output channel.
+ */
+export class ImljsonSchemaAssociations {
+	private readonly client: LanguageClient;
+	private readonly authorization: string;
+	private readonly environment: Environment;
+	private readonly cache = new Map<string, EnrichmentCacheEntry>();
+	private readonly fetchesInFlight = new Set<string>();
+
+	constructor({ client, authorization, environment }: ImljsonSchemaAssociationsDependencies) {
+		this.client = client;
+		this.authorization = authorization;
+		this.environment = environment;
+	}
+
+	/**
+	 * Re-evaluates Endpoint enrichment for the newly active editor. A no-op unless the editor is an
+	 * online-mode `api.imljson`/`publish.imljson`/`attach.imljson`/`detach.imljson` file (as opposed to a
+	 * local-dev workspace file, or e.g. a version-less connection/webhook file) on API v2.
+	 */
+	async handleActiveEditorChange(editor: vscode.TextEditor | undefined): Promise<void> {
+		try {
+			await this.refreshForEditor(editor);
+		} catch (err) {
+			log('warn', `ImljsonSchemaAssociations: unexpected error while handling active editor change: ${err}`);
+		}
+	}
+
+	private async refreshForEditor(editor: vscode.TextEditor | undefined): Promise<void> {
+		if (!editor || this.environment.version !== 2) {
+			return;
+		}
+
+		const fileName = editor.document.fileName;
+		if (!isFileBelongingToExtension(fileName) || !ENRICHABLE_BASENAMES.includes(path.basename(fileName))) {
+			return;
+		}
+
+		const appAndVersion = parseAppAndVersion(fileName);
+		if (!appAndVersion) {
+			return;
+		}
+
+		await this.ensureFreshEntry(appAndVersion);
+	}
+
+	private async ensureFreshEntry({ app, version }: { app: string; version: number }): Promise<void> {
+		const cacheKey = `${app}/${version}`;
+		const cached = this.cache.get(cacheKey);
+		if ((cached && Date.now() - cached.fetchedAt < ENRICHMENT_CACHE_TTL_MS) || this.fetchesInFlight.has(cacheKey)) {
+			return;
+		}
+
+		this.fetchesInFlight.add(cacheKey);
+		try {
+			const endpoints = await this.fetchEndpoints(app, version);
+			if (endpoints === null) {
+				// Fetch failed, or the response shape didn't match: keep the last-known-good entry (if any),
+				// just push its freshness window out so we don't refetch on every keystroke/editor change.
+				this.cache.set(cacheKey, { entry: cached?.entry, fetchedAt: Date.now() });
+				return;
+			}
+
+			this.cache.set(cacheKey, {
+				entry: {
+					// A subdirectory would break the schema's relative `sources.json#/...` refs — it must be a
+					// flat sibling of the real schema files, like the derived parameter schemas above.
+					uri: schemaFileUri(`api-enriched--${app}--v${version}.json`),
+					fileMatch: ENRICHABLE_BASENAMES.map((basename) => `**/apps-sdk/**/${app}/${version}/**/${basename}`),
+					schema: enrichApiSchemaWithEndpoints(getApiSchema(), endpoints),
+				},
+				fetchedAt: Date.now(),
+			});
+			await this.sendAssociations();
+		} finally {
+			this.fetchesInFlight.delete(cacheKey);
+		}
+	}
+
+	private async fetchEndpoints(app: string, version: number): Promise<SdkEndpointSchemaInfo[] | null> {
+		try {
+			const url = `${this.environment.baseUrl}/${Core.pathDeterminer(version, '__sdk')}${Core.pathDeterminer(
+				version,
+				'app',
+			)}/${app}/${version}/${Core.pathDeterminer(version, 'endpoint')}`;
+			const response = await Core.rpGet(url, this.authorization, { includeInputSchema: true }, true);
+			const appEndpoints: unknown = response?.appEndpoints;
+			if (!Array.isArray(appEndpoints)) {
+				return null;
+			}
+
+			return appEndpoints
+				.filter((item): item is { name: string; inputParameters?: unknown } => typeof item?.name === 'string')
+				.map((item) => ({ name: item.name, inputParameters: extractEndpointInputParameters(item.inputParameters) }));
+		} catch (err) {
+			log('debug', `ImljsonSchemaAssociations: failed to fetch endpoints for ${app}/${version}: ${err}`);
+			return null;
+		}
+	}
+
+	private async sendAssociations(): Promise<void> {
+		const enrichedEntries = [...this.cache.values()]
+			.map((cacheEntry) => cacheEntry.entry)
+			.filter((entry): entry is SchemaConfiguration => entry !== undefined);
+
+		await this.client.sendNotification(schemaAssociationsNotificationType, [
+			...getStaticAndDerivedSchemaAssociations(),
+			...enrichedEntries,
+		]);
+	}
 }

--- a/src/services/imljson-schema-associations.ts
+++ b/src/services/imljson-schema-associations.ts
@@ -8,7 +8,11 @@ import { log } from '../output-channel';
 import { isFileBelongingToExtension } from '../temp-dir';
 import type { Environment } from '../types/environment.types';
 import * as LanguageServersSettings from '../LanguageServersSettings';
-import { enrichApiSchemaWithEndpoints, extractEndpointInputParameters, type SdkEndpointSchemaInfo } from './endpoint-api-enrichment';
+import {
+	enrichApiSchemaWithEndpoints,
+	extractEndpointInputParameters,
+	type SdkEndpointSchemaInfo,
+} from './endpoint-api-enrichment';
 import { buildEndpointParametersSchema } from './endpoint-parameters-schema';
 
 /**
@@ -54,10 +58,9 @@ function schemaFileUri(filename: string): string {
  */
 function getParametersSchema(): Record<string, unknown> {
 	if (!parametersSchemaCache) {
-		parametersSchemaCache = JSON.parse(fs.readFileSync(path.join(schemasDir(), 'parameters.json'), 'utf8')) as Record<
-			string,
-			unknown
-		>;
+		parametersSchemaCache = JSON.parse(
+			fs.readFileSync(path.join(schemasDir(), 'parameters.json'), 'utf8'),
+		) as Record<string, unknown>;
 	}
 	return parametersSchemaCache;
 }
@@ -131,6 +134,7 @@ interface EnrichmentCacheEntry {
 	fetchedAt: number;
 }
 
+/** Constructor dependencies of {@link ImljsonSchemaAssociations}. */
 export interface ImljsonSchemaAssociationsDependencies {
 	client: LanguageClient;
 	authorization: string;
@@ -213,7 +217,9 @@ export class ImljsonSchemaAssociations {
 					// A subdirectory would break the schema's relative `sources.json#/...` refs — it must be a
 					// flat sibling of the real schema files, like the derived parameter schemas above.
 					uri: schemaFileUri(`api-enriched--${app}--v${version}.json`),
-					fileMatch: ENRICHABLE_BASENAMES.map((basename) => `**/apps-sdk/**/${app}/${version}/**/${basename}`),
+					fileMatch: ENRICHABLE_BASENAMES.map(
+						(basename) => `**/apps-sdk/**/${app}/${version}/**/${basename}`,
+					),
 					schema: enrichApiSchemaWithEndpoints(getApiSchema(), endpoints),
 				},
 				fetchedAt: Date.now(),
@@ -238,7 +244,10 @@ export class ImljsonSchemaAssociations {
 
 			return appEndpoints
 				.filter((item): item is { name: string; inputParameters?: unknown } => typeof item?.name === 'string')
-				.map((item) => ({ name: item.name, inputParameters: extractEndpointInputParameters(item.inputParameters) }));
+				.map((item) => ({
+					name: item.name,
+					inputParameters: extractEndpointInputParameters(item.inputParameters),
+				}));
 		} catch (err) {
 			log('debug', `ImljsonSchemaAssociations: failed to fetch endpoints for ${app}/${version}: ${err}`);
 			return null;

--- a/src/services/imljson-schema-associations.ts
+++ b/src/services/imljson-schema-associations.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { SchemaConfiguration } from 'vscode-json-languageservice';
+import { NotificationType } from 'vscode-languageclient/node';
+import * as LanguageServersSettings from '../LanguageServersSettings';
+import { buildEndpointParametersSchema } from './endpoint-parameters-schema';
+
+/**
+ * Notification carrying the IMLJSON schema associations sent to the language server. Re-sending it
+ * triggers `updateConfiguration()` + a diagnostics refresh on the server (see `jsonServer.ts`).
+ */
+export const schemaAssociationsNotificationType = new NotificationType<SchemaConfiguration[]>(
+	'imljson/schemaAssociations',
+);
+
+let parametersSchemaCache: Record<string, unknown> | undefined;
+
+/**
+ * Absolute `file://` URI of a schema file living next to the real ones in
+ * `syntaxes/imljson/schemas/`, resolved the same way as `LanguageServersSettings.getJsonSchemas()`.
+ */
+function schemaFileUri(filename: string): string {
+	const extension = vscode.extensions.getExtension('Integromat.apps-sdk')!;
+	return vscode.Uri.file(path.join(extension.extensionPath, 'syntaxes', 'imljson', 'schemas', filename)).toString();
+}
+
+/**
+ * Reads and parses `syntaxes/imljson/schemas/parameters.json` once, lazily, from the extension's own
+ * install path.
+ */
+function getParametersSchema(): Record<string, unknown> {
+	if (!parametersSchemaCache) {
+		const extension = vscode.extensions.getExtension('Integromat.apps-sdk')!;
+		const parametersSchemaPath = path.join(
+			extension.extensionPath,
+			'syntaxes',
+			'imljson',
+			'schemas',
+			'parameters.json',
+		);
+		parametersSchemaCache = JSON.parse(fs.readFileSync(parametersSchemaPath, 'utf8')) as Record<string, unknown>;
+	}
+	return parametersSchemaCache;
+}
+
+/**
+ * Returns the base IMLJSON schema associations (`package.json` -> `contributes` -> `jsonValidation`)
+ * plus the derived Endpoint Input/Output Parameters schemas. The latter aren't real files — see
+ * {@link buildEndpointParametersSchema} — but their URIs are flat siblings of the real schema files
+ * (a non-existent filename in the same directory) so their relative `sources.json#/...` refs still
+ * resolve to real files.
+ */
+export function getStaticAndDerivedSchemaAssociations(): SchemaConfiguration[] {
+	const parametersSchema = getParametersSchema();
+
+	return [
+		...LanguageServersSettings.getJsonSchemas(),
+		{
+			uri: schemaFileUri('endpoint-input-parameters.json'),
+			fileMatch: ['inputParameters.imljson', '*.input.iml.json'],
+			schema: buildEndpointParametersSchema(parametersSchema, 'inputSchema'),
+		},
+		{
+			uri: schemaFileUri('endpoint-output-parameters.json'),
+			fileMatch: ['outputParameters.imljson', '*.output.iml.json'],
+			schema: buildEndpointParametersSchema(parametersSchema, 'outputSchema'),
+		},
+	];
+}

--- a/src/services/imljson-schema-associations.ts
+++ b/src/services/imljson-schema-associations.ts
@@ -26,9 +26,12 @@ export const schemaAssociationsNotificationType = new NotificationType<SchemaCon
 /**
  * Basenames whose api schema is eligible for online-mode Endpoint enrichment (see
  * {@link ImljsonSchemaAssociations}) — the files whose `endpoint`/`pagination.endpoint` directives
- * reference a sibling Endpoint by name.
+ * reference a sibling Endpoint by name. `attach.imljson`/`detach.imljson` are webhook-only codes and
+ * webhooks are non-versionable (`Core.isVersionable`), so their temp paths never carry the version
+ * segment `parseAppAndVersion` requires — they're excluded here since they could never actually match.
+ * `publish.imljson` likely doesn't occur in v2 online paths either, but is kept for parity/completeness.
  */
-const ENRICHABLE_BASENAMES = ['api.imljson', 'publish.imljson', 'attach.imljson', 'detach.imljson'];
+const ENRICHABLE_BASENAMES = ['api.imljson', 'publish.imljson'];
 
 /** How long a fetched (or failed) app/version entry is considered fresh, in milliseconds. */
 const ENRICHMENT_CACHE_TTL_MS = 60_000;
@@ -166,8 +169,8 @@ export class ImljsonSchemaAssociations {
 
 	/**
 	 * Re-evaluates Endpoint enrichment for the newly active editor. A no-op unless the editor is an
-	 * online-mode `api.imljson`/`publish.imljson`/`attach.imljson`/`detach.imljson` file (as opposed to a
-	 * local-dev workspace file, or e.g. a version-less connection/webhook file) on API v2.
+	 * online-mode `api.imljson`/`publish.imljson` file (as opposed to a local-dev workspace file, or e.g.
+	 * a version-less connection/webhook file) on API v2.
 	 */
 	async handleActiveEditorChange(editor: vscode.TextEditor | undefined): Promise<void> {
 		try {
@@ -232,10 +235,14 @@ export class ImljsonSchemaAssociations {
 
 	private async fetchEndpoints(app: string, version: number): Promise<SdkEndpointSchemaInfo[] | null> {
 		try {
-			const url = `${this.environment.baseUrl}/${Core.pathDeterminer(version, '__sdk')}${Core.pathDeterminer(
-				version,
+			// `Core.pathDeterminer` switches on the *API* version (this.environment.version, always 2 here —
+			// see the guard in refreshForEditor), not the app's own major `version`, which only belongs in
+			// the URL path segment itself (see EndpointCommands.endpointsCollectionUrl for the same shape).
+			const apiVersion = this.environment.version;
+			const url = `${this.environment.baseUrl}/${Core.pathDeterminer(apiVersion, '__sdk')}${Core.pathDeterminer(
+				apiVersion,
 				'app',
-			)}/${app}/${version}/${Core.pathDeterminer(version, 'endpoint')}`;
+			)}/${app}/${version}/${Core.pathDeterminer(apiVersion, 'endpoint')}`;
 			const response = await Core.rpGet(url, this.authorization, { includeInputSchema: true }, true);
 			const appEndpoints: unknown = response?.appEndpoints;
 			if (!Array.isArray(appEndpoints)) {

--- a/syntaxes/imljson/schemas/api.json
+++ b/syntaxes/imljson/schemas/api.json
@@ -8,6 +8,12 @@
 				"url": {
 					"$ref": "sources.json#/definitions/url"
 				},
+				"endpoint": {
+					"$ref": "#/definitions/endpoint"
+				},
+				"input": {
+					"$ref": "#/definitions/input"
+				},
 				"encodeUrl": {
 					"$ref": "sources.json#/definitions/encodeUrl"
 				},
@@ -54,7 +60,8 @@
 					"$ref": "sources.json#/definitions/oauth-1"
 				},
 				"pagination": {
-					"$ref": "sources.json#/definitions/pagination"
+					"description": "Directive to specify how to process paginated responses.",
+					"type": "object"
 				},
 				"output": {
 					"$ref": "response.json#/definitions/output"
@@ -131,6 +138,127 @@
 			},
 			"then": {
 				"required": ["url", "body"]
+			},
+			"allOf": [
+				{
+					"$comment": "An endpoint call evaluates `input` in the caller's context before the call, so `input` only makes sense alongside `endpoint`.",
+					"dependencies": {
+						"input": ["endpoint"]
+					}
+				},
+				{
+					"$comment": "An endpoint call runs a sibling Endpoint instead of an HTTP request, so the HTTP-request directives are dead config, and pagination is driven by the module (endpointPagination) instead of the classic HTTP pagination.",
+					"if": {
+						"required": ["endpoint"]
+					},
+					"then": {
+						"errorMessage": "Not allowed when 'endpoint' is present — the request runs a sibling Endpoint instead of an HTTP request.",
+						"properties": {
+							"url": false,
+							"method": false,
+							"headers": false,
+							"qs": false,
+							"body": false,
+							"encodeUrl": false,
+							"ca": false,
+							"type": false,
+							"gzip": false,
+							"aws": false,
+							"followRedirects": false,
+							"followAllRedirects": false,
+							"oauth": false,
+							"pagination": {
+								"$ref": "#/definitions/endpointPagination"
+							}
+						}
+					},
+					"else": {
+						"properties": {
+							"pagination": {
+								"$ref": "sources.json#/definitions/pagination"
+							}
+						}
+					}
+				}
+			],
+			"additionalProperties": false
+		},
+		"endpoint": {
+			"$id": "#endpoint",
+			"description": "Runs a sibling Endpoint in-process instead of an HTTP request. Only a single call is made — sequencing across multiple calls or pagination is driven at the module level via the pagination directive. A plain string is shorthand for { \"name\": <string> }.",
+			"oneOf": [
+				{
+					"$comment": "Listed before the shorthand string ref: when neither branch matches (e.g. `{}`), Monaco's oneOf mismatch-reporting breaks ties by picking whichever alternative was tested first, so this order is what makes a malformed object surface \"missing property 'name'\" instead of \"expected string\".",
+					"type": "object",
+					"properties": {
+						"name": {
+							"$ref": "#/definitions/endpointName"
+						},
+						"connection": {
+							"description": "Overrides the connection used for the Endpoint call, evaluated in the caller's context.",
+							"type": "string",
+							"doNotSuggest": true
+						}
+					},
+					"required": ["name"],
+					"additionalProperties": false
+				},
+				{
+					"$ref": "#/definitions/endpointName"
+				}
+			]
+		},
+		"endpointName": {
+			"$id": "#endpointName",
+			"type": "string",
+			"description": "The name of the sibling Endpoint to run."
+		},
+		"input": {
+			"$id": "#input",
+			"type": "object",
+			"description": "Input passed to the Endpoint, evaluated in the caller's context before the call."
+		},
+		"paginationEndpoint": {
+			"$id": "#paginationEndpoint",
+			"description": "Overrides the sibling Endpoint to run for the pagination request. When omitted, the base endpoint is reused. A plain string is shorthand for { \"name\": <string> }.",
+			"oneOf": [
+				{
+					"$comment": "Listed before the shorthand string ref — see the same $comment on #/definitions/endpoint.",
+					"type": "object",
+					"properties": {
+						"name": {
+							"$ref": "#/definitions/endpointName"
+						}
+					},
+					"required": ["name"],
+					"additionalProperties": false
+				},
+				{
+					"$ref": "#/definitions/endpointName"
+				}
+			]
+		},
+		"endpointPagination": {
+			"$id": "#endpointPagination",
+			"description": "Directive to specify how to process pagination for a request that runs a sibling Endpoint.",
+			"type": "object",
+			"properties": {
+				"mergeWithParent": {
+					"description": "This directive specifies if to merge pagination.input with the base request's input, or not.",
+					"type": "boolean",
+					"default": true
+				},
+				"endpoint": {
+					"$ref": "#/definitions/paginationEndpoint"
+				},
+				"input": {
+					"description": "Input passed to the pagination Endpoint call, evaluated in the caller's context.",
+					"type": "object"
+				},
+				"condition": {
+					"description": "This directive specifies whether to execute the pagination request or not.",
+					"type": ["boolean", "string"]
+				}
 			},
 			"additionalProperties": false
 		}

--- a/syntaxes/imljson/schemas/base.json
+++ b/syntaxes/imljson/schemas/base.json
@@ -29,6 +29,9 @@
 				"body": {
 					"$ref": "sources.json#/definitions/body"
 				},
+				"timeout": {
+					"$ref": "sources.json#/definitions/timeout"
+				},
 				"type": {
 					"$ref": "enums.json#/definitions/request-type"
 				},

--- a/syntaxes/imljson/schemas/endpoint-api.json
+++ b/syntaxes/imljson/schemas/endpoint-api.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$comment": "An Endpoint's own api is a single HTTP request. It reuses the module/RPC request definition but forbids the endpoint directive, because an Endpoint may not invoke other Endpoints (one level only).",
+	"allOf": [
+		{
+			"$ref": "api.json#/definitions/request"
+		},
+		{
+			"not": {
+				"required": ["endpoint"]
+			}
+		}
+	]
+}

--- a/syntaxes/imljson/schemas/sources.json
+++ b/syntaxes/imljson/schemas/sources.json
@@ -289,6 +289,13 @@
 				}
 			}
 		},
+		"timeout": {
+			"$id": "#timeout",
+			"description": "This directive specifies the request timeout in milliseconds. The maximum timeout value is 300,000 milliseconds.",
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 300000
+		},
 		"repeat": {
 			"$id": "#repeat",
 			"description": "Repeats a request under a certain condition with a predefined delay in milliseconds. The maximum number of repeats can be bounded by the repeat.limit.",


### PR DESCRIPTION
https://make.atlassian.net/browse/SPEED-914

## Reasoning
PR #362 added the Endpoint SDK-app component, but the IMLJSON validation schemas here were never updated to match — they still validated the pre-Endpoint shape of `api.json`. Web-zone's Monaco schemas (imt-web-zone PR #8193) are the reference for the correct shape.

## What
- Synced `api.json`/`sources.json`/`base.json` with web-zone's endpoint directive, pagination, and `timeout` rewrite; added a dedicated `endpoint-api.json` that combines (via `jsonValidation` `fileMatch`) with `api.json` to ban the `endpoint` directive and array-root form specifically on Endpoint api files.
- Derive the Endpoint Input/Output Parameters JSON schemas at runtime from `parameters.json` (requiring `help`/`name`, banning the `banner` type, constraining the top-level `json` field name) instead of duplicating them as static files.
- In online mode (API v2), dynamically enrich `api.json` per app+version with that app's real Endpoint names and per-endpoint Input Parameter suggestions, fetched and cached (60s TTL) with silent, non-blocking failure handling. Local development is unaffected (static schemas, free-string endpoint name).
- Input Parameter suggestions also unwrap a wrapped JSON Schema (a `type: "json"` field whose `schema` describes the whole input object) via `@makehq/forman-schema`, Make's own JSON-Schema↔Forman-Schema converter, instead of just the flat form-builder array — recursing into nested `collection`-typed sub-fields (e.g. `input.address.city`), for both the unwrapped-schema and native Forman-field cases. Arrays are intentionally left as leaves (not recursed).

## Where
- Schemas: `syntaxes/imljson/schemas/` + `package.json` (`contributes.jsonValidation`)
- New logic: `src/services/endpoint-parameters-schema.ts`, `src/services/endpoint-api-enrichment.ts` (now depends on `@makehq/forman-schema`), `src/services/imljson-schema-associations.ts`, wired into `src/extension.ts`
- Tests: fixture/unit coverage for all of the above, plus e2e additions in `src/extension.test.ts`