### PR TITLE
chore: remove legacy Integromat support

### DIFF
--- a/src/Core.ts
+++ b/src/Core.ts
@@ -50,14 +50,6 @@ export function contextGuard(context: any) {
 	return true;
 }
 
-export function envGuard(environment: Environment, available: number[]) {
-	if (!available.includes(environment.version)) {
-		vscode.window.showErrorMessage('Not available in this version of Integromat.');
-		return false;
-	}
-	return true;
-}
-
 export function isFilled(subject: string, object: string, thing: any, article?: string, the?: boolean) {
 	if (thing === undefined || thing === '' || thing === null) {
 		vscode.window.showWarningMessage(
@@ -137,11 +129,7 @@ export async function executePlain(authorization: string, value: string, url: st
 }
 
 export async function getAppObject(environment: Environment, authorization: string, app: SdkApp) {
-	if (environment.version === 2) {
-		return (await rpGet(`${environment.baseUrl}/sdk/apps/${app.name}/${app.version}`, authorization)).app;
-	} else {
-		return await rpGet(`${environment.baseUrl}/app/${app.name}/${app.version}`, authorization);
-	}
+	return (await rpGet(`${environment.baseUrl}/sdk/apps/${app.name}/${app.version}`, authorization)).app;
 }
 
 export function getIconHtml(uri: string, color: string, dir: string) {
@@ -202,38 +190,28 @@ export function jsonString(text: any, sectionGuard: string | undefined): string 
 	return text;
 }
 
-export function pathDeterminer(version: number, originalPath: string): string {
-	switch (version) {
-		case 2:
-			switch (originalPath) {
-				case 'app':
-					return 'apps';
-				case 'connection':
-					return 'connections';
-				case 'webhook':
-					return 'webhooks';
-				case 'module':
-					return 'modules';
-				case 'rpc':
-					return 'rpcs';
-				case 'function':
-					return 'functions';
-				case 'endpoint':
-					return 'endpoints';
-				case 'change':
-					return 'changes';
-				case '__sdk':
-					return 'sdk/';
-				default:
-					return '';
-			}
-		case 1:
+export function pathDeterminer(originalPath: string): string {
+	switch (originalPath) {
+		case 'app':
+			return 'apps';
+		case 'connection':
+			return 'connections';
+		case 'webhook':
+			return 'webhooks';
+		case 'module':
+			return 'modules';
+		case 'rpc':
+			return 'rpcs';
+		case 'function':
+			return 'functions';
+		case 'endpoint':
+			return 'endpoints';
+		case 'change':
+			return 'changes';
+		case '__sdk':
+			return 'sdk/';
 		default:
-			if (originalPath === '__sdk') {
-				return '';
-			} else {
-				return originalPath;
-			}
+			return '';
 	}
 }
 

--- a/src/QuickPick.js
+++ b/src/QuickPick.js
@@ -5,9 +5,8 @@ const { showError } = require('./error-handling');
 
 module.exports = {
 	connections: async function (environment, authorization, app, allow_no) {
-		const uri = `${environment.baseUrl}/${Core.pathDeterminer(environment.version, '__sdk')}${Core.pathDeterminer(environment.version, 'app')}/${app.name}/${Core.pathDeterminer(environment.version, 'connection')}`;
-		let response = await Core.rpGet(uri, authorization);
-		response = environment.version === 1 ? response : response[camelCase(`appConnections`)];
+		const uri = `${environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${Core.pathDeterminer('connection')}`;
+		const response = (await Core.rpGet(uri, authorization))[camelCase(`appConnections`)];
 		try {
 			let connections = response.map(connection => {
 				return {
@@ -26,9 +25,8 @@ module.exports = {
 	},
 
 	webhooks: async function (environment, authorization, app, allow_no) {
-		const uri = `${environment.baseUrl}/${Core.pathDeterminer(environment.version, '__sdk')}${Core.pathDeterminer(environment.version, 'app')}/${app.name}/${Core.pathDeterminer(environment.version, 'webhook')}`;
-		let response = await Core.rpGet(uri, authorization);
-		response = environment.version === 1 ? response : response[camelCase(`appWebhooks`)];
+		const uri = `${environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${Core.pathDeterminer('webhook')}`;
+		const response = (await Core.rpGet(uri, authorization))[camelCase(`appWebhooks`)];
 		try {
 			let webhooks = response.map(webhook => {
 				return {
@@ -47,14 +45,8 @@ module.exports = {
 	},
 
 	countries: async function (environment, authorization) {
-		let countries;
-		let code = 'code';
-		if (environment.version === 2) {
-			countries = (await Core.rpGet(`${environment.baseUrl}/enums/countries`, authorization)).countries
-			code = 'code2'
-		} else {
-			countries = await Core.rpGet(`${environment.baseUrl}/country`, authorization)
-		}
+		const code = 'code2';
+		const countries = (await Core.rpGet(`${environment.baseUrl}/enums/countries`, authorization)).countries
 		try {
 			return countries.map(country => {
 				return {
@@ -69,12 +61,7 @@ module.exports = {
 	},
 
 	languages: async function (environment, authorization, context) {
-		let response;
-		if (environment.version === 2) {
-			response = (await Core.rpGet(`${environment.baseUrl}/enums/languages`, authorization)).languages
-		} else {
-			response = await Core.rpGet(`${environment.baseUrl}/language`, authorization)
-		}
+		const response = (await Core.rpGet(`${environment.baseUrl}/enums/languages`, authorization)).languages
 		let languages = response.map(language => {
 			if (language == null) { return }
 			return {
@@ -99,18 +86,13 @@ module.exports = {
 	},
 
 	allApps: async function (environment, authorization) {
-		let response;
-		if (environment.version === 2) {
-			let appsResponse, noOfApps = [], offset = 0
-			do {
-				appsResponse = await Core.rpGet(`${environment.baseUrl}/admin/sdk/apps`, authorization, { all: true , "pg[offset]": offset * 10000 })
-				noOfApps = noOfApps.concat(appsResponse.apps)
-				offset++
-			} while (appsResponse.apps.length === 10000)
-			response = noOfApps
-		} else {
-			response = await Core.rpGet(`${environment.baseUrl}/app`, authorization, { all: true })
-		}
+		let appsResponse, noOfApps = [], offset = 0
+		do {
+			appsResponse = await Core.rpGet(`${environment.baseUrl}/admin/sdk/apps`, authorization, { all: true , "pg[offset]": offset * 10000 })
+			noOfApps = noOfApps.concat(appsResponse.apps)
+			offset++
+		} while (appsResponse.apps.length === 10000)
+		const response = noOfApps
 		try {
 			const apps = [];
 			const used = [];
@@ -131,12 +113,7 @@ module.exports = {
 	},
 
 	favApps: async function (environment, authorization) {
-		let response;
-		if (environment.version === 2) {
-			response = (await Core.rpGet(`${environment.baseUrl}/admin/sdk/apps`, authorization)).apps
-		} else {
-			response = await Core.rpGet(`${environment.baseUrl}/app`, authorization)
-		}
+		const response = (await Core.rpGet(`${environment.baseUrl}/admin/sdk/apps`, authorization)).apps
 		try {
 			return response.map(app => {
 				return {

--- a/src/commands/AccountCommands.js
+++ b/src/commands/AccountCommands.js
@@ -25,24 +25,18 @@ class AccountCommands {
 			if (!Core.isFilled("apikey", "your account", apikey, "An", false)) { return }
 
 			// who-am-I endpoint test
-			if (environment.version === 2) {
-				let uri = `http${environment.unsafe === true ? '' : 's'}://${environment.url}${environment.noVersionPath === true ? '' : `/v${environment.version}`}/users/me`
-				try {
-					await axios({
-						url: uri,
-						headers: {
-							Authorization: `Token ${apikey}`,
-							'imt-apps-sdk-version': Meta.version
-						}
-					})
-				} catch (err) {
-					showError(err, 'apps-sdk.login');
-					return;
-				}
-			} else {
-				let uri = `https://${environment.url}/v1/whoami`
-				let response = await Core.rpGet(uri, `Token ${apikey}`)
-				if (response === undefined) { return }
+			const uri = `http${environment.unsafe === true ? '' : 's'}://${environment.url}${environment.noVersionPath === true ? '' : `/v${environment.version}`}/users/me`
+			try {
+				await axios({
+					url: uri,
+					headers: {
+						Authorization: `Token ${apikey}`,
+						'imt-apps-sdk-version': Meta.version
+					}
+				})
+			} catch (err) {
+				showError(err, 'apps-sdk.login');
+				return;
 			}
 
 			// Update environments, save everything and reload the window

--- a/src/commands/AppCommands.js
+++ b/src/commands/AppCommands.js
@@ -106,30 +106,16 @@ class AppCommands {
 
 				let changes = false;
 
-				if (_environment.version === 2) {
-					// If there are some apps to be added
-					if (appsToAdd.length > 0) {
-						await Core.addEntity(_authorization, { name: appsToAdd }, `${_environment.baseUrl}/admin/sdk/apps/favorites`);
-						changes = true;
-					}
+				// If there are some apps to be added
+				if (appsToAdd.length > 0) {
+					await Core.addEntity(_authorization, { name: appsToAdd }, `${_environment.baseUrl}/admin/sdk/apps/favorites`);
+					changes = true;
+				}
 
-					// If there are some apps to be removed
-					if (appsToRemove.length > 0) {
-						await Core.deleteEntity(_authorization, { name: appsToRemove }, `${_environment.baseUrl}/admin/sdk/apps/favorites`);
-						changes = true;
-					}
-				} else {
-					// If there are some apps to be added
-					if (appsToAdd.length > 0) {
-						await Core.addEntity(_authorization, { name: appsToAdd }, `${_environment.baseUrl}/favorite`);
-						changes = true;
-					}
-
-					// If there are some apps to be removed
-					if (appsToRemove.length > 0) {
-						await Core.deleteEntity(_authorization, { name: appsToRemove }, `${_environment.baseUrl}/favorite`);
-						changes = true;
-					}
+				// If there are some apps to be removed
+				if (appsToRemove.length > 0) {
+					await Core.deleteEntity(_authorization, { name: appsToRemove }, `${_environment.baseUrl}/admin/sdk/apps/favorites`);
+					changes = true;
 				}
 
 				// If there were some changes, refresh the app tree
@@ -163,20 +149,18 @@ class AppCommands {
 				}
 
 				let version = 1;
-				if ([2].includes(_environment.version)) {
-					let response = await Core.rpGet(`${_environment.baseUrl}/users/me`, _authorization);
+				let response = await Core.rpGet(`${_environment.baseUrl}/users/me`, _authorization);
 
-					//check if a user have "Can create Apps without ID suffix" feature on admin
-					if (response && response.authUser && response.authUser.features && response.authUser.features.allow_apps) {
-						// Version Propmpt
-						version = await vscode.window.showInputBox({
-							prompt: 'Enter app version, if you\'re not creating a new version of an existing app, keep 1',
-							value: version
-						});
-					}
-					if (!Core.isFilled('version', 'app', version, 'A')) {
-						return;
-					}
+				//check if a user have "Can create Apps without ID suffix" feature on admin
+				if (response && response.authUser && response.authUser.features && response.authUser.features.allow_apps) {
+					// Version Propmpt
+					version = await vscode.window.showInputBox({
+						prompt: 'Enter app version, if you\'re not creating a new version of an existing app, keep 1',
+						value: version
+					});
+				}
+				if (!Core.isFilled('version', 'app', version, 'A')) {
+					return;
 				}
 
 				// Description propmpt
@@ -217,35 +201,23 @@ class AppCommands {
 				}
 
 				// Build URI and prepare countries list
-				const uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}`;
+				const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}`;
 				countries = countries.map(item => {
 					return item.description;
 				});
 
 				// Send the request
-				if (_environment.version === 2) {
-					// TODO : Language not sent, formula tweak needed
-					await Core.addEntity(_authorization, {
-						'name': id,
-						'label': label,
-						'version': parseInt(version) || 1,
-						'description': description,
-						'theme': theme,
-						'language': language.description,
-						'audience': countries.length === 0 ? 'global' : 'countries',
-						'countries': countries.length === 0 ? undefined : countries
-					}, uri);
-				} else {
-					await Core.addEntity(_authorization, {
-						'name': id,
-						'label': label,
-						'description': description,
-						'theme': theme,
-						'language': language.description,
-						'private': true,
-						'countries': countries
-					}, uri);
-				}
+				// TODO : Language not sent, formula tweak needed
+				await Core.addEntity(_authorization, {
+					'name': id,
+					'label': label,
+					'version': parseInt(version) || 1,
+					'description': description,
+					'theme': theme,
+					'language': language.description,
+					'audience': countries.length === 0 ? 'global' : 'countries',
+					'countries': countries.length === 0 ? undefined : countries
+				}, uri);
 				appsProvider.refresh();
 
 			}));
@@ -320,31 +292,21 @@ class AppCommands {
 			}
 
 			// Build URI and prepare countries list
-			const uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}/${context.version}`;
+			const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}/${context.version}`;
 			countries = countries.map(country => {
 				return country.description;
 			});
 			countries = countries.length > 0 ? countries : undefined;
 
 			// Send the request
-			if (_environment.version === 2) {
-				await Core.patchEntity(_authorization, {
-					label: label,
-					theme: theme,
-					description: description,
-					language: language.description,
-					audience: countries === undefined ? 'global' : 'countries',
-					countries: countries
-				}, uri);
-			} else {
-				await Core.editEntity(_authorization, {
-					label: label,
-					theme: theme,
-					description: description,
-					language: language.description,
-					countries: countries
-				}, uri);
-			}
+			await Core.patchEntity(_authorization, {
+				label: label,
+				theme: theme,
+				description: description,
+				language: language.description,
+				audience: countries === undefined ? 'global' : 'countries',
+				countries: countries
+			}, uri);
 			appsProvider.refresh();
 		}));
 
@@ -372,7 +334,7 @@ class AppCommands {
 					return;
 				case 'Yes': {
 					// Set URI and send the request
-					const uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}/${context.version}`;
+					const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}/${context.version}`;
 					await axios({
 						method: 'DELETE',
 						url: uri,
@@ -479,7 +441,7 @@ class AppCommands {
 
 					// Prepare request options
 					const options = {
-						url: `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/icon`,
+						url: `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/icon`,
 						method: 'PUT',
 						headers: {
 							Authorization: _authorization,
@@ -526,13 +488,8 @@ class AppCommands {
 				return;
 			}
 
-			const urn = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}/${context.version}`;
-			let app = await Core.rpGet(`${urn}`, _authorization);
-
-			// ApiFlip
-			if (_environment.version === 2) {
-				app = app.app;
-			}
+			const urn = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}/${context.version}`;
+			const app = (await Core.rpGet(`${urn}`, _authorization)).app;
 
 			const languages = await QuickPick.languages(_environment, _authorization);
 			app.language = languages.find(language => language.description === app.language);
@@ -560,13 +517,8 @@ class AppCommands {
 				}
 			);
 
-			if (_environment.version === 2) {
-				app.modules = (await Core.rpGet(`${urn}/modules`, _authorization)).appModules.map(m => m.approved);
-				app.rpcsCount = (await Core.rpGet(`${urn}/rpcs`, _authorization)).appRpcs.length;
-			} else {
-				app.modules = (await Core.rpGet(`${urn}/module`, _authorization)).map(m => m.approved);
-				app.rpcsCount = (await Core.rpGet(`${urn}/rpc`, _authorization)).length;
-			}
+			app.modules = (await Core.rpGet(`${urn}/modules`, _authorization)).appModules.map(m => m.approved);
+			app.rpcsCount = (await Core.rpGet(`${urn}/rpcs`, _authorization)).appRpcs.length;
 
 			panel.webview.html = Core.getAppDetailHtml(path.join(__dirname, '..', '..'));
 
@@ -607,7 +559,7 @@ class AppCommands {
 					break;
 				case 'Yes': {
 					// Set URI and send the request
-					const uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/private`;
+					const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/private`;
 					try {
 						await Core.executePlain(_authorization, '', uri);
 						appsProvider.refresh();
@@ -645,7 +597,7 @@ class AppCommands {
 					break;
 				case 'Yes': {
 					// Set URI and send the request
-					const uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/public`;
+					const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/public`;
 					try {
 						await Core.executePlain(_authorization, '', uri);
 						appsProvider.refresh();
@@ -696,9 +648,9 @@ class AppCommands {
 
 				const archive = path.join(DIR, app.name);
 				await asyncfile.mkdir(archive);
-				const urnNoVersion = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}`;
-				const urnNoApp = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}${_environment.version !== 2 ? `/${context.name}` : ''}`;
-				const urn = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}/${context.version}`;
+				const urnNoVersion = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}`;
+				const urnNoApp = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}`;
+				const urn = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}/${context.version}`;
 
 				try {
 					/**
@@ -708,8 +660,7 @@ class AppCommands {
 						return;
 					}
 					progress.report({ increment: 2, message: `${app.label} - Gathering Metadata` });
-					let a = await Core.rpGet(`${urn}`, _authorization);
-					if (_environment.version === 2) { a = a.app }
+					const a = (await Core.rpGet(`${urn}`, _authorization)).app;
 					await asyncfile.writeFile(path.join(archive, `metadata.json`), JSON.stringify(pick(a, ['name', 'label', 'version', 'theme', 'language', 'countries']), null, 4));
 
 					/**
@@ -736,8 +687,7 @@ class AppCommands {
 					if (canceled) {
 						return;
 					}
-					let connections = await Core.rpGet(`${urnNoVersion}/${Core.pathDeterminer(_environment.version, 'connection')}`, _authorization);
-					if (_environment.version === 2) { connections = connections.appConnections }
+					const connections = (await Core.rpGet(`${urnNoVersion}/${Core.pathDeterminer('connection')}`, _authorization)).appConnections
 					if (connections.length === 0) {
 						progress.report({ increment: 7, message: `${app.label} - No Connections (skipping)` });
 					} else {
@@ -755,8 +705,7 @@ class AppCommands {
 						progress.report({
 							increment: 0.125 * progressPercentage, message: `${app.label} - Exporting Connection ${connection.label} (metadata)`
 						});
-						let c = (await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer(_environment.version, 'connection')}/${connection.name}`, _authorization));
-						if (_environment.version === 2) { c = c.appConnection }
+						const c = (await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer('connection')}/${connection.name}`, _authorization)).appConnection
 						await asyncfile.writeFile(path.join(archivePath, `metadata.json`), JSON.stringify(pick(c, ['name', 'label', 'type']), null, 4));
 
 						// Get Corresponding Sources
@@ -765,7 +714,7 @@ class AppCommands {
 								increment: (0.875 * progressPercentage) * (0.25), message: `${app.label} - Exporting Connection ${connection.label} (${key})`
 							});
 							await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-								Core.jsonString(await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer(_environment.version, 'connection')}/${connection.name}/${key}`, _authorization), key));
+								Core.jsonString(await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer('connection')}/${connection.name}/${key}`, _authorization), key));
 						}
 					}
 
@@ -775,8 +724,7 @@ class AppCommands {
 					if (canceled) {
 						return;
 					}
-					let rpcs = await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'rpc')}`, _authorization);
-					if (_environment.version === 2) { rpcs = rpcs.appRpcs }
+					const rpcs = (await Core.rpGet(`${urn}/${Core.pathDeterminer('rpc')}`, _authorization)).appRpcs
 					if (rpcs.length === 0) {
 						progress.report({ increment: 17, message: `${app.label} - No RPCs (skipping)` });
 					} else {
@@ -792,8 +740,7 @@ class AppCommands {
 
 						// Get RPC Metadata
 						progress.report({ increment: (0.25 * progressPercentage), message: `${app.label} - Exporting RPC ${rpc.label} (metadata)` });
-						let r = (await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'rpc')}/${rpc.name}`, _authorization));
-						if (_environment.version === 2) { r = r.appRpc }
+						const r = (await Core.rpGet(`${urn}/${Core.pathDeterminer('rpc')}/${rpc.name}`, _authorization)).appRpc
 						await asyncfile.writeFile(path.join(archivePath, `metadata.json`),
 							JSON.stringify(pick(r, ['name', 'label', 'connection']), null, 4));
 
@@ -801,7 +748,7 @@ class AppCommands {
 						for (const key of [`api`, `parameters`]) {
 							progress.report({ increment: (0.75 * progressPercentage) * (0.5), message: `${app.label} - Exporting RPC ${rpc.label} (${key})` });
 							await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-								Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'rpc')}/${rpc.name}/${key}`, _authorization), key));
+								Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer('rpc')}/${rpc.name}/${key}`, _authorization), key));
 						}
 					}
 
@@ -811,8 +758,7 @@ class AppCommands {
 					if (canceled) {
 						return;
 					}
-					let webhooks = await Core.rpGet(`${urnNoVersion}/${Core.pathDeterminer(_environment.version, 'webhook')}`, _authorization);
-					if (_environment.version === 2) { webhooks = webhooks.appWebhooks }
+					const webhooks = (await Core.rpGet(`${urnNoVersion}/${Core.pathDeterminer('webhook')}`, _authorization)).appWebhooks
 					if (webhooks.length === 0) {
 						progress.report({ increment: 12, message: `${app.label} - No Webhooks (skipping)` });
 					} else {
@@ -828,17 +774,16 @@ class AppCommands {
 
 						// Get Webhook Metadata
 						progress.report({ increment: 0.1 * progressPercentage, message: `${app.label} - Exporting Webhook ${webhook.label} (metadata)` });
-						let w = await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer(_environment.version, 'webhook')}/${webhook.name}`, _authorization)
-						if (_environment.version === 2) { w = w.appWebhook }
+						const w = (await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer('webhook')}/${webhook.name}`, _authorization)).appWebhook
 						await asyncfile.writeFile(path.join(archivePath, `metadata.json`), JSON.stringify(pick(w, ['name', 'label', 'connection', 'type']), null, 4));
 
 						// Get Corresponding Sources
-						for (const key of [`api`, `parameters`, `attach`, `detach`, `scope`].concat(_environment.version === 2 ? [`update`] : [])) {
+						for (const key of [`api`, `parameters`, `attach`, `detach`, `scope`].concat([`update`])) {
 							progress.report({
 								increment: (0.9 * progressPercentage) * (0.2), message: `${app.label} - Exporting Webhook ${webhook.label} (${key})`
 							});
 							await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-								Core.jsonString(await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer(_environment.version, 'webhook')}/${webhook.name}/${key}`, _authorization), key));
+								Core.jsonString(await Core.rpGet(`${urnNoApp}/${Core.pathDeterminer('webhook')}/${webhook.name}/${key}`, _authorization), key));
 						}
 					}
 
@@ -848,8 +793,7 @@ class AppCommands {
 					if (canceled) {
 						return;
 					}
-					let modules = await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'module')}`, _authorization);
-					if (_environment.version === 2) { modules = modules.appModules }
+					const modules = (await Core.rpGet(`${urn}/${Core.pathDeterminer('module')}`, _authorization)).appModules
 					if (modules.length === 0) {
 						progress.report({ increment: 41, message: `${app.label} - No Modules (skipping)` });
 					} else {
@@ -860,14 +804,13 @@ class AppCommands {
 						if (canceled) {
 							return;
 						}
-						if (_environment.version === 2) { module.type_id = module.typeId; delete module.typeId; }
+						module.type_id = module.typeId; delete module.typeId;
 						const archivePath = path.join(archive, 'modules', module.name);
 						await asyncfile.mkdir(archivePath);
 
 						// Get Module Metadata
 						progress.report({ increment: 0.07 * progressPercentage, message: `${app.label} - Exporting Module ${module.label} (metadata)` });
-						let m = await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'module')}/${module.name}`, _authorization)
-						if (_environment.version === 2) { m = m.appModule; m.type_id = m.typeId; delete m.typeId }
+						const m = (await Core.rpGet(`${urn}/${Core.pathDeterminer('module')}/${module.name}`, _authorization)).appModule; m.type_id = m.typeId; delete m.typeId
 						const metadata = pick(m, ['name', 'label', 'description', 'type_id', 'connection', 'webhook']);
 						metadata.type = getModuleDefFromId(metadata.type_id).type;
 						delete metadata.type_id;
@@ -885,7 +828,7 @@ class AppCommands {
 										increment: (0.93 * progressPercentage) * (0.16), message: `${app.label} - Exporting Module ${module.label} (${key})`
 									});
 									await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'module')}/${module.name}/${key}`, _authorization), key));
+										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer('module')}/${module.name}/${key}`, _authorization), key));
 								}
 								break;
 							// Trigger
@@ -895,7 +838,7 @@ class AppCommands {
 										increment: (0.93 * progressPercentage) * (0.16), message: `${app.label} - Exporting Module ${module.label} (${key})`
 									});
 									await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'module')}/${module.name}/${key}`, _authorization), key));
+										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer('module')}/${module.name}/${key}`, _authorization), key));
 								}
 								break;
 							// Instant trigger
@@ -905,7 +848,7 @@ class AppCommands {
 										increment: (0.93 * progressPercentage) * (0.25), message: `${app.label} - Exporting Module ${module.label} (${key})`
 									});
 									await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'module')}/${module.name}/${key}`, _authorization), key));
+										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer('module')}/${module.name}/${key}`, _authorization), key));
 								}
 								break;
 							// Responder
@@ -915,7 +858,7 @@ class AppCommands {
 										increment: (0.93 * progressPercentage) * (0.33), message: `${app.label} - Exporting Module ${module.label} (${key})`
 									});
 									await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'module')}/${module.name}/${key}`, _authorization), key));
+										Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer('module')}/${module.name}/${key}`, _authorization), key));
 								}
 								break;
 						}
@@ -927,8 +870,7 @@ class AppCommands {
 					if (canceled) {
 						return;
 					}
-					let functions = await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'function')}`, _authorization);
-					if (_environment.version === 2) { functions = functions.appFunctions }
+					const functions = (await Core.rpGet(`${urn}/${Core.pathDeterminer('function')}`, _authorization)).appFunctions
 					if (functions.length === 0) {
 						progress.report({ increment: 7, message: `${app.label} - No Functions (skipping)` });
 					} else {
@@ -948,23 +890,21 @@ class AppCommands {
 								increment: progressPercentage * 0.5, message: `${app.label} - Exporting Function ${fun.name}${fun.args} (${key})`
 							});
 							await asyncfile.writeFile(path.join(archivePath, `${key}.js`),
-								(await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'function')}/${fun.name}/${key}`, _authorization)) || '');
+								(await Core.rpGet(`${urn}/${Core.pathDeterminer('function')}/${fun.name}/${key}`, _authorization)) || '');
 						}
 					}
 
 					/**
-					 * 9 - Get Endpoints (API v2 only; feature may be disabled → skip defensively)
+					 * 9 - Get Endpoints (feature may be disabled → skip defensively)
 					 */
 					if (canceled) {
 						return;
 					}
 					let endpoints = [];
 					try {
-						if (_environment.version === 2) {
-							// Suppress the error dialog: the feature may be disabled on the environment — the
-							// catch below skips endpoints instead of surfacing an error and aborting the export.
-							endpoints = (await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'endpoint')}`, _authorization, undefined, true)).appEndpoints || [];
-						}
+						// Suppress the error dialog: the feature may be disabled on the environment — the
+						// catch below skips endpoints instead of surfacing an error and aborting the export.
+						endpoints = (await Core.rpGet(`${urn}/${Core.pathDeterminer('endpoint')}`, _authorization, undefined, true)).appEndpoints || [];
 					} catch {
 						// Endpoints feature may be disabled on the server (or unsupported). Skip without aborting the export.
 						endpoints = [];
@@ -982,8 +922,7 @@ class AppCommands {
 							await asyncfile.mkdir(archivePath);
 
 							// Get Endpoint Metadata (incl. `context` and `annotations` — these are metadata fields)
-							let e = (await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'endpoint')}/${endpoint.name}`, _authorization));
-							e = e.appEndpoint;
+							const e = (await Core.rpGet(`${urn}/${Core.pathDeterminer('endpoint')}/${endpoint.name}`, _authorization)).appEndpoint;
 							await asyncfile.writeFile(path.join(archivePath, `metadata.json`),
 								JSON.stringify(pick(e, ['name', 'label', 'description', 'context', 'annotations', 'attachedAccounts']), null, 4));
 
@@ -991,7 +930,7 @@ class AppCommands {
 							for (const key of [`api`, `scope`, `inputParameters`, `outputParameters`]) {
 								progress.report({ increment: endpointProgress * 0.25, message: `${app.label} - Exporting Endpoint ${endpoint.label} (${key})` });
 								await asyncfile.writeFile(path.join(archivePath, `${key}.imljson`),
-									Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer(_environment.version, 'endpoint')}/${endpoint.name}/${key}`, _authorization), key));
+									Core.jsonString(await Core.rpGet(`${urn}/${Core.pathDeterminer('endpoint')}/${endpoint.name}/${key}`, _authorization), key));
 							}
 						}
 					}
@@ -1020,9 +959,6 @@ class AppCommands {
 					/**
 					 * 11 - Note the format
 					 */
-					if (canceled) {
-						return
-					}
 					await asyncfile.writeFile(path.join(archive, `.sdk`), JSON.stringify({
 						version: 2
 					}, null, 4));
@@ -1182,7 +1118,6 @@ class AppCommands {
 				/** JSON content of `metadata.json` file */
 				app.metadata = JSON.parse(data.toString());
 
-
 				// Get .sdk metadata raw directly
 				const _sdk = JSON.parse((await new Promise(resolve => {
 					const f = entries.find(entry => entry.entryName.match(`${app.metadata.name}/.sdk`));
@@ -1197,6 +1132,9 @@ class AppCommands {
 						}));
 					}
 				})));
+				if (_sdk.version !== 2) {
+					throw new Error(`This ZIP archive was exported from API v${_sdk.version} (legacy Integromat format), which is no longer supported. Please re-export the app from a current Make environment.`);
+				}
 
 				app.base = (await getData(validator, entries, `${app.metadata.name}/base.imljson`)).toString();
 				app.readme = (await getData(validator, entries, `${app.metadata.name}/readme.md`)).toString();
@@ -1205,10 +1143,10 @@ class AppCommands {
 				} catch (e) {
 					app.icon = undefined;
 				}
-				app.connections = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer(_sdk.version, 'connection'), [`api`, `scope`, `scopes`, `parameters`], 'imljson');
-				app.rpcs = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer(_sdk.version, 'rpc'), [`api`, `parameters`], 'imljson');
-				app.webhooks = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer(_sdk.version, 'webhook'), [`api`, `parameters`, `attach`, `detach`, `scope`, `update`], 'imljson');
-				app.modules = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer(_sdk.version, 'module'), {
+				app.connections = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer('connection'), [`api`, `scope`, `scopes`, `parameters`], 'imljson');
+				app.rpcs = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer('rpc'), [`api`, `parameters`], 'imljson');
+				app.webhooks = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer('webhook'), [`api`, `parameters`, `attach`, `detach`, `scope`, `update`], 'imljson');
+				app.modules = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer('module'), {
 					action: [`api`, `parameters`, `expect`, `interface`, `samples`, `scope`],
 					search: [`api`, `parameters`, `expect`, `interface`, `samples`, `scope`],
 					universal: [`api`, `parameters`, `expect`, `interface`, `samples`, `scope`],
@@ -1216,9 +1154,8 @@ class AppCommands {
 					instant_trigger: [`api`, `parameters`, `interface`, `samples`],
 					responder: [`api`, `parameters`, `expect`],
 				}, 'imljson');
-				app.functions = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer(_sdk.version, 'function'), ['code', 'test'], 'js', false);
-				// Endpoints exist in API v2 only. Guard so a v2 zip imported into a v1 env doesn't attempt them.
-				app.endpoints = _sdk.version === 2 ? await parseComponent(validator, entries, app.metadata, Core.pathDeterminer(_sdk.version, 'endpoint'), [`api`, `scope`, `inputParameters`, `outputParameters`], 'imljson') : [];
+				app.functions = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer('function'), ['code', 'test'], 'js', false);
+				app.endpoints = await parseComponent(validator, entries, app.metadata, Core.pathDeterminer('endpoint'), [`api`, `scope`, `inputParameters`, `outputParameters`], 'imljson');
 				return app;
 
 				// validator.count should equal entries.length;
@@ -1242,7 +1179,7 @@ class AppCommands {
 				// Create and upload connections
 				app.connections.forEach((connection) => {
 					// Create connection component in Make
-					requests.push(makeRequestProto(`Connection ${connection.metadata.label}`, `${remoteApp.name}/${Core.pathDeterminer(_environment.version, 'connection')}`, 'POST', 'application/json',
+					requests.push(makeRequestProto(`Connection ${connection.metadata.label}`, `${remoteApp.name}/${Core.pathDeterminer('connection')}`, 'POST', 'application/json',
 						JSON.stringify(extract(connection.metadata, ['label', 'type'])),
 						[
 							{
@@ -1257,18 +1194,18 @@ class AppCommands {
 					// Upload connection's codes
 					[`api`, `parameters`].forEach(code => {
 						requests.push(makeRequestProto(`Connection ${connection.metadata.label} - ${code}`,
-							`${_environment.version !== 2 ? `${remoteApp.name}/` : ''}${Core.pathDeterminer(_environment.version, 'connection')}/#CONN_NAME#/${code}`, 'PUT', 'application/jsonc', connection[code]));
+							`${Core.pathDeterminer('connection')}/#CONN_NAME#/${code}`, 'PUT', 'application/jsonc', connection[code]));
 					});
 					[`scope`, `scopes`].forEach(code => {
 						requests.push(makeRequestProto(`Connection ${connection.metadata.label} - ${code}`,
-							`${_environment.version !== 2 ? `${remoteApp.name}/` : ''}${Core.pathDeterminer(_environment.version, 'connection')}/#CONN_NAME#/${code}`, 'PUT', 'application/jsonc', connection[code]));
+							`${Core.pathDeterminer('connection')}/#CONN_NAME#/${code}`, 'PUT', 'application/jsonc', connection[code]));
 					});
 				});
 				// Create and Upload RPCs
 				app.rpcs.forEach((rpc) => {
 					// Create new RPC in Make
 					requests.push(makeRequestProto(`RPC ${rpc.metadata.label}`,
-						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'rpc')}`, 'POST', 'application/json', JSON.stringify(rpc.metadata), undefined,
+						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('rpc')}`, 'POST', 'application/json', JSON.stringify(rpc.metadata), undefined,
 						[
 							{
 								key: 'connection',
@@ -1278,14 +1215,14 @@ class AppCommands {
 					// Upload RPC's codes
 					[`api`, `parameters`].forEach(code => {
 						requests.push(makeRequestProto(`RPC ${rpc.metadata.label} - ${code}`,
-							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'rpc')}/${rpc.metadata.name}/${code}`, 'PUT', 'application/jsonc', rpc[code]));
+							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('rpc')}/${rpc.metadata.name}/${code}`, 'PUT', 'application/jsonc', rpc[code]));
 					});
 				});
 				// Create and Upload Webhooks to Make
 				app.webhooks.forEach((webhook) => {
 					// Create new webhook in Make
 					requests.push(makeRequestProto(`Webhook ${webhook.metadata.label}`,
-						`${remoteApp.name}/${Core.pathDeterminer(_environment.version, 'webhook')}`, 'POST', 'application/json', JSON.stringify(extract(webhook.metadata,
+						`${remoteApp.name}/${Core.pathDeterminer('webhook')}`, 'POST', 'application/json', JSON.stringify(extract(webhook.metadata,
 							['label', 'type', 'connection'])),
 						[
 							{
@@ -1304,9 +1241,9 @@ class AppCommands {
 							}
 						]));
 					// Upload webhooks's codes
-					([`api`, `parameters`, `attach`, `detach`, `scope`].concat(_environment.version === 2 ? [`update`] : [])).forEach(code => {
+					([`api`, `parameters`, `attach`, `detach`, `scope`].concat([`update`])).forEach(code => {
 						requests.push(makeRequestProto(`Webhook ${webhook.metadata.label} - ${code}`,
-							`${_environment.version !== 2 ? `${remoteApp.name}/` : ''}${Core.pathDeterminer(_environment.version, 'webhook')}/#WEBHOOK_NAME#/${code}`, 'PUT', 'application/jsonc', webhook[code]));
+							`${Core.pathDeterminer('webhook')}/#WEBHOOK_NAME#/${code}`, 'PUT', 'application/jsonc', webhook[code]));
 					});
 				});
 				// Create and Upload Modules
@@ -1317,7 +1254,7 @@ class AppCommands {
 
 					// Create module in Make
 					requests.push(makeRequestProto(`Module ${appModule.metadata.label}`,
-						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'module')}`, 'POST', 'application/json', JSON.stringify(body), undefined,
+						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('module')}`, 'POST', 'application/json', JSON.stringify(body), undefined,
 						[
 							{
 								key: 'connection',
@@ -1348,7 +1285,7 @@ class AppCommands {
 					}
 					codes.forEach(code => {
 						requests.push(makeRequestProto(`Module ${appModule.metadata.label} - ${code}`,
-							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'module')}/${appModule.metadata.name}/${code}`,
+							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('module')}/${appModule.metadata.name}/${code}`,
 							'PUT', 'application/jsonc', appModule[code]));
 					});
 				});
@@ -1356,28 +1293,27 @@ class AppCommands {
 				app.functions.forEach(appFunction => {
 					const functionName = /(?:function )(.+)(?:\()/.exec(appFunction.code)[1];
 					requests.push(makeRequestProto(`Function ${functionName}`,
-						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'function')}`, 'POST', 'application/json', JSON.stringify({
+						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('function')}`, 'POST', 'application/json', JSON.stringify({
 							name: functionName
 						})));
 					[`code`, `test`].forEach(code => {
 						requests.push(makeRequestProto(`Function ${functionName} - ${code}`,
-							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'function')}/${functionName}/${code}`,
+							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('function')}/${functionName}/${code}`,
 							'PUT', 'application/javascript', appFunction[code]));
 					});
 				});
-				// Create & upload endpoints (API v2 only). Endpoint name is client-specified (stable), so it is
+				// Create & upload endpoints. Endpoint name is client-specified (stable), so it is
 				// referenced directly; only `attachedAccounts` (connection refs) may be remapped on import.
-				// Guard on v2 so a v2 zip imported into a v1 env doesn't attempt endpoint requests.
-				(_environment.version === 2 ? (app.endpoints || []) : []).forEach((endpoint) => {
+				(app.endpoints || []).forEach((endpoint) => {
 					const name = endpoint.metadata.name;
 					// Create endpoint in Make
 					requests.push(makeRequestProto(`Endpoint ${endpoint.metadata.label}`,
-						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'endpoint')}`,
+						`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('endpoint')}`,
 						'POST', 'application/json', JSON.stringify(extract(endpoint.metadata, ['name', 'label', 'description']))));
 					// Upload endpoint's sections
 					[`api`, `scope`, `inputParameters`, `outputParameters`].forEach(code => {
 						requests.push(makeRequestProto(`Endpoint ${endpoint.metadata.label} - ${code}`,
-							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'endpoint')}/${name}/${code}`,
+							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('endpoint')}/${name}/${code}`,
 							'PUT', 'application/jsonc', endpoint[code]));
 					});
 					// PATCH the metadata-only fields: context, annotations, attachedAccounts (connection refs).
@@ -1388,7 +1324,7 @@ class AppCommands {
 					if (attachedAccounts.length > 0) { patchBody.attachedAccounts = attachedAccounts; }
 					if (Object.keys(patchBody).length > 0) {
 						requests.push(makeRequestProto(`Endpoint ${endpoint.metadata.label} - metadata`,
-							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer(_environment.version, 'endpoint')}/${name}`,
+							`${remoteApp.name}/${remoteApp.version}/${Core.pathDeterminer('endpoint')}/${name}`,
 							'PATCH', 'application/json', JSON.stringify(patchBody), undefined, undefined,
 							attachedAccounts.length > 0
 								? [{ key: 'attachedAccounts', slugs: attachedAccounts.map(connName => `connection-${connName}`) }]
@@ -1416,15 +1352,13 @@ class AppCommands {
 			const entries = zip.getEntries();
 			const app = await parseApp(entries);
 
-			if (_environment.version === 2) {
-				app.metadata.audience = ((!Array.isArray(app.metadata.countries) || app.metadata.countries.length === 0) ? 'global' : 'countries')
-				if (app.metadata.audience === 'global') {
-					delete app.metadata.countries;
-				}
-				delete app.metadata.version;
-				if (!app.metadata.description) {
-					app.metadata.description = `Imported app ${app.metadata.label}.`
-				}
+			app.metadata.audience = ((!Array.isArray(app.metadata.countries) || app.metadata.countries.length === 0) ? 'global' : 'countries')
+			if (app.metadata.audience === 'global') {
+				delete app.metadata.countries;
+			}
+			delete app.metadata.version;
+			if (!app.metadata.description) {
+				app.metadata.description = `Imported app ${app.metadata.label}.`
 			}
 
 			// App ID (Name) prompt
@@ -1438,11 +1372,11 @@ class AppCommands {
 			}
 
 			// Create new app in Make cloud
-			let remoteApp = await Core.addEntity(_authorization, app.metadata, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}`);
+			let remoteApp = await Core.addEntity(_authorization, app.metadata, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}`);
 			if (!remoteApp) {
 				return;
 			}
-			if (_environment.version === 2) { remoteApp = remoteApp.app }
+			remoteApp = remoteApp.app
 
 			/** API requests list to push all app parts to Make */
 			const requests = buildRequestQueue(app, remoteApp);
@@ -1469,7 +1403,7 @@ class AppCommands {
 					if (shouldStop) {
 						return;
 					}
-					const uri = replaceSlugs(store, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${r.endpoint}`);
+					const uri = replaceSlugs(store, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${r.endpoint}`);
 					progress.report({
 						increment: (100 / requests.length),
 						message: r._label
@@ -1508,7 +1442,7 @@ class AppCommands {
 						transformResponse: (data) => (data),
 					};
 
-					if (_environment.version === 2 && requestConfig.method === 'POST' && requestConfig.headers['content-type'] === 'application/json') {
+					if (requestConfig.method === 'POST' && requestConfig.headers['content-type'] === 'application/json') {
 						// TODO Check, if it is ok to send data to Axios stringified
 						const j = JSON.parse(requestConfig.data);
 						requestConfig.data = JSON.stringify(Object.keys(j).reduce((p, c) => {
@@ -1525,7 +1459,7 @@ class AppCommands {
 							let parsed = JSON.parse(axiosResponse.data);
 
 							// Autoparse the nested object
-							if (_environment.version === 2 && Object.keys(parsed).length === 1 && Object.keys(parsed)[0].startsWith('app')) {
+							if (Object.keys(parsed).length === 1 && Object.keys(parsed)[0].startsWith('app')) {
 								parsed = parsed[Object.keys(parsed)[0]];
 							}
 
@@ -1542,7 +1476,7 @@ class AppCommands {
 		 * Clone app
 		 */
 		vscode.commands.registerCommand('apps-sdk.app.clone', async (context) => {
-			if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) { return; }
+			if (!Core.contextGuard(context)) { return; }
 
 			// Form Data
 
@@ -1594,7 +1528,7 @@ class AppCommands {
 				return;
 			}
 
-			const uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}/${context.version}/clone`;
+			const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}/${context.version}/clone`;
 			try {
 				await Core.addEntity(_authorization, form, uri);
 				appsProvider.refresh();

--- a/src/commands/ChangesCommands.js
+++ b/src/commands/ChangesCommands.js
@@ -20,7 +20,7 @@ class ChangesCommands {
 		vscode.commands.registerCommand('apps-sdk.changes.show', async function (code) {
 
 			// Get the diff
-			const url = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.getApp(code).name}/${Core.getApp(code).version}/${Core.pathDeterminer(_environment.version, 'change')}/${code.change}`
+			const url = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.getApp(code).name}/${Core.getApp(code).version}/${Core.pathDeterminer('change')}/${code.change}`
 			let diffdata = await Core.rpGet(url, _authorization)
 
 			// Prepare paths for files
@@ -77,9 +77,9 @@ class ChangesCommands {
 				case "No":
 					vscode.window.showInformationMessage("No changes were commited.")
 					break
-				case "Yes":
+				case "Yes": {
 					// Compose URI
-					let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}/${context.version}/commit`
+					const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}/${context.version}/commit`
 					try {
 						await axios({
 							method: 'POST',
@@ -98,7 +98,8 @@ class ChangesCommands {
 					catch (err) {
 						showError(err, 'apps-sdk.changes.commit');
 					}
-					break
+					break;
+				}
 			}
 		})
 
@@ -122,9 +123,9 @@ class ChangesCommands {
 				case "No":
 					vscode.window.showInformationMessage("No changes were rolled back.")
 					break
-				case "Yes":
+				case "Yes": {
 					// Compose URI
-					let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.name}/${context.version}/rollback`
+					const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.name}/${context.version}/rollback`
 					try {
 						await axios({
 							method: 'POST',
@@ -139,7 +140,8 @@ class ChangesCommands {
 					catch (err) {
 						showError(err, 'apps-sdk.changes.rollback');
 					}
-					break
+					break;
+				}
 			}
 		})
 	}

--- a/src/commands/CommonCommands.ts
+++ b/src/commands/CommonCommands.ts
@@ -34,8 +34,8 @@ export class CommonCommands {
 			// Set URI and send the request
 			context.apiPath = context.apiPath === undefined ? context.supertype : context.apiPath;
 			const url = Core.isVersionable(context.apiPath) ?
-				`${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, context.apiPath)}/${context.name}` :
-				`${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.pathDeterminer(_environment.version, context.apiPath)}/${context.name}`;
+				`${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/${Core.pathDeterminer(context.apiPath)}/${context.name}` :
+				`${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.pathDeterminer(context.apiPath)}/${context.name}`;
 			try {
 				// Delete the entity
 				await requestMakeApi({

--- a/src/commands/ConnectionCommands.js
+++ b/src/commands/ConnectionCommands.js
@@ -26,7 +26,7 @@ class ConnectionCommands {
 			if (!Core.isFilled("type", "connection", type)) { return }
 
 			// Prepare URI
-			let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${Core.pathDeterminer(_environment.version, 'connection')}`
+			const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${Core.pathDeterminer('connection')}`
 
 			// Send the request
 			try {
@@ -57,15 +57,10 @@ class ConnectionCommands {
 			if (!Core.isFilled("label", "connection", label)) { return }
 
 
-			if (_environment.version === 2) {
-				let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.pathDeterminer(_environment.version, 'connection')}/${context.name}`
-				await Core.patchEntity(_authorization, {
-					label: label
-				}, uri);
-			} else {
-				let uri = `${_environment.baseUrl}/app/${context.parent.parent.name}/connection/${context.name}/label`
-				await Core.editEntityPlain(_authorization, label, uri)
-			}
+			const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.pathDeterminer('connection')}/${context.name}`
+			await Core.patchEntity(_authorization, {
+				label: label
+			}, uri);
 			appsProvider.refresh();
 		}));
 	}

--- a/src/commands/CoreCommands.ts
+++ b/src/commands/CoreCommands.ts
@@ -85,7 +85,7 @@ export class CoreCommands {
 		// metadata field. Detect them generically (driven by `CodeDef.metadataBacked`) and save by PATCH-ing
 		// the component with `{ [apiCodeType]: file }` instead of PUT-ing to a `/{apiCodeType}` section URL.
 		const metadataBackedCode = getMetadataBackedCodes().find(({ componentType, apiCodeType }) =>
-			new RegExp(`/${Core.pathDeterminer(this._environment.version, componentType)}/[^/]+/${apiCodeType}$`).test(url),
+			new RegExp(`/${Core.pathDeterminer(componentType)}/[^/]+/${apiCodeType}$`).test(url),
 		);
 		if (metadataBackedCode) {
 			url = url.replace(new RegExp(`/${metadataBackedCode.apiCodeType}$`), '');
@@ -293,17 +293,12 @@ export class CoreCommands {
 			}
 
 			// RPC list url
-			const url = `${this._environment.baseUrl}/${Core.pathDeterminer(
-				this._environment.version,
-				'__sdk',
-			)}${Core.pathDeterminer(this._environment.version, 'app')}/${app}/${version}/${Core.pathDeterminer(
-				this._environment.version,
-				'rpc',
-			)}`;
+			const url = `${this._environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer(
+				'app',
+			)}/${app}/${version}/${Core.pathDeterminer('rpc')}`;
 
 			// Get list of RPCs
-			const response = await Core.rpGet(url, this._authorization);
-			const items: { name: string }[] = this._environment.version === 1 ? response : response.appRpcs;
+			const items: { name: string }[] = (await Core.rpGet(url, this._authorization)).appRpcs;
 			const rpcs = items.map((rpc) => {
 				return `rpc://${rpc.name}`;
 			});
@@ -343,17 +338,12 @@ export class CoreCommands {
 			}
 
 			// IML functions list url
-			const url = `${this._environment.baseUrl}/${Core.pathDeterminer(
-				this._environment.version,
-				'__sdk',
-			)}${Core.pathDeterminer(this._environment.version, 'app')}/${app}/${version}/${Core.pathDeterminer(
-				this._environment.version,
-				'function',
-			)}`;
+			const url = `${this._environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer(
+				'app',
+			)}/${app}/${version}/${Core.pathDeterminer('function')}`;
 
 			// Get list of existing app's custom IML functions
-			const response = await Core.rpGet(url, this._authorization);
-			const items: { name: string }[] = this._environment.version === 1 ? response : response.appFunctions;
+			const items: { name: string }[] = (await Core.rpGet(url, this._authorization)).appFunctions;
 			const imls = items.map((iml) => {
 				return `${iml.name}()`;
 			});
@@ -485,15 +475,10 @@ export class CoreCommands {
 				this.currentGroupsProvider.dispose();
 			}
 
-			const url = `${this._environment.baseUrl}/${Core.pathDeterminer(
-				this._environment.version,
-				'__sdk',
-			)}${Core.pathDeterminer(this._environment.version, 'app')}/${app}/${version}/${Core.pathDeterminer(
-				this._environment.version,
-				'module',
-			)}`;
-			const response = await Core.rpGet(url, this._authorization);
-			const modules = this._environment.version === 1 ? response : response.appModules;
+			const url = `${this._environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer(
+				'app',
+			)}/${app}/${version}/${Core.pathDeterminer('module')}`;
+			const modules = (await Core.rpGet(url, this._authorization)).appModules;
 			const groupsProvider = new GroupsProvider(modules);
 			groupsProvider.buildCompletionItems();
 			this.currentGroupsProvider = vscode.languages.registerCompletionItemProvider(
@@ -529,86 +514,44 @@ export class CoreCommands {
 			switch (apiPath) {
 				case 'rpc':
 				case 'rpcs':
-					if (this._environment.version === 1) {
-						connection = (
-							await Core.rpGet(
-								`${this._environment.baseUrl}/app/${app}/${version}/rpc/${crumbs[4]}`,
-								this._authorization,
-							)
-						).connection;
-					} else {
-						connection = (
-							await Core.rpGet(
-								`${this._environment.baseUrl}/sdk/apps/${app}/${version}/rpcs/${crumbs[4]}`,
-								this._authorization,
-							)
-						).appRpc.connection;
-					}
+					connection = (
+						await Core.rpGet(
+							`${this._environment.baseUrl}/sdk/apps/${app}/${version}/rpcs/${crumbs[4]}`,
+							this._authorization,
+						)
+					).appRpc.connection;
 					break;
 				case 'module':
 				case 'modules':
-					if (this._environment.version === 1) {
-						connection = (
-							await Core.rpGet(
-								`${this._environment.baseUrl}/app/${app}/${version}/module/${crumbs[4]}`,
-								this._authorization,
-							)
-						).connection;
-					} else {
-						connection = (
-							await Core.rpGet(
-								`${this._environment.baseUrl}/sdk/apps/${app}/${version}/modules/${crumbs[4]}`,
-								this._authorization,
-							)
-						).appModule.connection;
-					}
+					connection = (
+						await Core.rpGet(
+							`${this._environment.baseUrl}/sdk/apps/${app}/${version}/modules/${crumbs[4]}`,
+							this._authorization,
+						)
+					).appModule.connection;
 					break;
 				case 'webhook':
 				case 'webhooks':
-					if (this._environment.version === 1) {
-						connection = (
-							await Core.rpGet(
-								`${this._environment.baseUrl}/app/${app}/webhook/${crumbs[4]}`,
-								this._authorization,
-							)
-						).connection;
-					} else {
-						connection = (
-							await Core.rpGet(
-								`${this._environment.baseUrl}/sdk/apps/webhooks/${crumbs[4]}`,
-								this._authorization,
-							)
-						).appWebhook.connection;
-					}
+					connection = (
+						await Core.rpGet(
+							`${this._environment.baseUrl}/sdk/apps/webhooks/${crumbs[4]}`,
+							this._authorization,
+						)
+					).appWebhook.connection;
 					break;
 			}
 
 			if (connection) {
-				let connectionType;
-				let connectionSource;
-				if (this._environment.version === 1) {
-					connectionType = (
-						await Core.rpGet(
-							`${this._environment.baseUrl}/app/${app}/connection/${connection}`,
-							this._authorization,
-						)
-					).type;
-					connectionSource = await Core.rpGet(
-						`${this._environment.baseUrl}/app/${app}/connection/${connection}/api`,
+				const connectionType = (
+					await Core.rpGet(
+						`${this._environment.baseUrl}/sdk/apps/connections/${connection}`,
 						this._authorization,
-					);
-				} else {
-					connectionType = (
-						await Core.rpGet(
-							`${this._environment.baseUrl}/sdk/apps/connections/${connection}`,
-							this._authorization,
-						)
-					).appConnection.type;
-					connectionSource = await Core.rpGet(
-						`${this._environment.baseUrl}/sdk/apps/connections/${connection}/api`,
-						this._authorization,
-					);
-				}
+					)
+				).appConnection.type;
+				const connectionSource = await Core.rpGet(
+					`${this._environment.baseUrl}/sdk/apps/connections/${connection}/api`,
+					this._authorization,
+				);
 				const dataProvider = new DataProvider(connectionSource, connectionType);
 				dataProvider.getAvailableVariables();
 				this.currentDataProvider = vscode.languages.registerCompletionItemProvider(
@@ -639,20 +582,14 @@ export class CoreCommands {
 			'apps-sdk.load-open-source',
 			catchError('Example code load from API', async (item) => {
 				// Compose directory structure
-				let urn = `/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(
-					_environment.version,
-					'app',
-				)}${_environment.version !== 2 ? `/${Core.getApp(item).name}` : ''}`;
-				let urnForFile = `/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(
-					_environment.version,
-					'app',
-				)}/${Core.getApp(item).name}`;
+				let urn = `/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}`;
+				let urnForFile = `/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${
+					Core.getApp(item).name
+				}`;
 
 				// Add version to URN for versionable items
 				if (Core.isVersionable(item.apiPath)) {
-					urn += `${_environment.version === 2 ? `/${Core.getApp(item).name}` : ''}/${
-						Core.getApp(item).version
-					}`;
+					urn += `/${Core.getApp(item).name}/${Core.getApp(item).version}`;
 					urnForFile += `/${Core.getApp(item).version}`;
 				}
 
@@ -751,20 +688,14 @@ export class CoreCommands {
 				// TODO Refactor this to use `pullComponentCode()` function.
 
 				// Compose directory structure
-				let urn = `/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(
-					_environment.version,
-					'app',
-				)}${_environment.version !== 2 ? `/${Core.getApp(item).name}` : ''}`;
-				let urnForFile = `/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(
-					_environment.version,
-					'app',
-				)}/${Core.getApp(item).name}`;
+				let urn = `/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}`;
+				let urnForFile = `/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${
+					Core.getApp(item).name
+				}`;
 
 				// Add version to URN for versionable items
 				if (Core.isVersionable(item.apiPath)) {
-					urn += `${_environment.version === 2 ? `/${Core.getApp(item).name}` : ''}/${
-						Core.getApp(item).version
-					}`;
+					urn += `/${Core.getApp(item).name}/${Core.getApp(item).version}`;
 					urnForFile += `/${Core.getApp(item).version}`;
 				}
 

--- a/src/commands/EndpointCommands.ts
+++ b/src/commands/EndpointCommands.ts
@@ -24,10 +24,9 @@ export class EndpointCommands {
 	static async register(appsProvider: AppsProvider, _authorization: string, _environment: Environment) {
 		/** Base URL of the endpoints collection for the app owning `context` (an endpoint tree Item). */
 		const endpointsCollectionUrl = (app: { name: string; version: number }): string =>
-			`${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(
-				_environment.version,
+			`${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer(
 				'app',
-			)}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, 'endpoint')}`;
+			)}/${app.name}/${app.version}/${Core.pathDeterminer('endpoint')}`;
 
 		/**
 		 * New endpoint
@@ -35,7 +34,7 @@ export class EndpointCommands {
 		vscode.commands.registerCommand(
 			'apps-sdk.endpoint.new',
 			catchError('Endpoint creation', async (context: any) => {
-				if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) {
+				if (!Core.contextGuard(context)) {
 					return;
 				}
 				const app = context.parent;
@@ -78,7 +77,7 @@ export class EndpointCommands {
 		vscode.commands.registerCommand(
 			'apps-sdk.endpoint.edit-metadata',
 			catchError('Endpoint metadata edit', async (context: any) => {
-				if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) {
+				if (!Core.contextGuard(context)) {
 					return;
 				}
 
@@ -114,7 +113,7 @@ export class EndpointCommands {
 		vscode.commands.registerCommand(
 			'apps-sdk.endpoint.visibility.public',
 			catchError('Endpoint publish', async (context: any) => {
-				if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) {
+				if (!Core.contextGuard(context)) {
 					return;
 				}
 				await Core.executePlain(
@@ -132,7 +131,7 @@ export class EndpointCommands {
 		vscode.commands.registerCommand(
 			'apps-sdk.endpoint.visibility.private',
 			catchError('Endpoint make private', async (context: any) => {
-				if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) {
+				if (!Core.contextGuard(context)) {
 					return;
 				}
 				await Core.executePlain(
@@ -152,7 +151,7 @@ export class EndpointCommands {
 		vscode.commands.registerCommand(
 			'apps-sdk.endpoint.edit-annotations',
 			catchError('Endpoint annotations edit', async (context: any) => {
-				if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) {
+				if (!Core.contextGuard(context)) {
 					return;
 				}
 				const endpointUrl = `${endpointsCollectionUrl(context.parent.parent)}/${context.name}`;
@@ -193,7 +192,7 @@ export class EndpointCommands {
 		vscode.commands.registerCommand(
 			'apps-sdk.endpoint.edit-connections',
 			catchError('Endpoint connections edit', async (context: any) => {
-				if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) {
+				if (!Core.contextGuard(context)) {
 					return;
 				}
 				const app = context.parent.parent;

--- a/src/commands/EnvironmentCommands.js
+++ b/src/commands/EnvironmentCommands.js
@@ -76,7 +76,7 @@ class EnvironmentCommands {
 				url: url,
 				name: name,
 				apikey: apikey,
-				version: 2, // 2 = Make, 1 = Integromat (deprecated). TODO remove `version`
+				version: 2, // 2 = Make, 1 = Integromat (deprecated, not supported by this extension anymore).
 			})
 
 			// Save all and reload the window

--- a/src/commands/FunctionCommands.ts
+++ b/src/commands/FunctionCommands.ts
@@ -38,7 +38,7 @@ export class FunctionCommands {
 			if (!Core.isFilled('name', 'function', name)) { return }
 
 			// Add the new entity. Refresh the tree or show the error
-			await Core.addEntity(_authorization, { name: name }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, 'function')}`)
+			await Core.addEntity(_authorization, { name: name }, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/${Core.pathDeterminer('function')}`)
 			appsProvider.refresh()
 		}));
 
@@ -80,14 +80,14 @@ export class FunctionCommands {
 					return
 				}
 				// If all checks passed, set URN
-				urn = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${crumbs[4]}/${crumbs[3]}/${Core.pathDeterminer(_environment.version, 'function')}`
+				urn = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${crumbs[4]}/${crumbs[3]}/${Core.pathDeterminer('function')}`
 				functionName = `${crumbs[1]}`
 			}
 
 			// Else parse from context
 			else {
 				// Set correct URN (if called from function or core or test)
-				urn = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.getApp(context).name}/${Core.getApp(context).version}/${Core.pathDeterminer(_environment.version, 'function')}`
+				urn = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.getApp(context).name}/${Core.getApp(context).version}/${Core.pathDeterminer('function')}`
 				if (context.supertype === 'function') {
 					functionName = `${context.name}`
 				}
@@ -104,9 +104,7 @@ export class FunctionCommands {
 				Core.rpGet(`${urn}`, _authorization, { cols: ['name'] }),
 			]);
 
-			const functionList: { name: string }[] = _environment.version === 2
-				? (functionListResponse as any).appFunctions
-				: functionListResponse;
+			const functionList: { name: string }[] = (functionListResponse as any).appFunctions;
 
 			// Fetch each function's draft code via its direct endpoint
 			const userFunctions: CustomImlFunction[] = await Promise.all(

--- a/src/commands/ModuleCommands.js
+++ b/src/commands/ModuleCommands.js
@@ -99,7 +99,7 @@ class ModuleCommands {
             if (!Core.isFilled("type", "module", type)) { return }
 
             // Prepare URI and request body
-            let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, 'module')}`
+            let uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/${Core.pathDeterminer('module')}`
             let body = {
                 "name": id,
                 "label": label,
@@ -108,11 +108,9 @@ class ModuleCommands {
             }
 
             // ApiFlip
-            if (_environment.version === 2) {
-                body.typeId = parseInt(body.type_id);
-                delete body.type_id;
-				body.moduleInitMode = 'example';
-            }
+            body.typeId = parseInt(body.type_id);
+            delete body.type_id;
+            body.moduleInitMode = 'example';
 
             // Action type selector
             if (type.description === "4") {
@@ -196,27 +194,16 @@ class ModuleCommands {
 
             body.type_id = context.type
 
-            if (_environment.version === 2) {
-                try {
-                    body.label = label;
-                    delete body.type_id;
-                    if (body.crud === null) {
-                        delete body.crud;
-                    }
-                    await Core.patchEntity(_authorization, body, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`)
-                    appsProvider.refresh()
-                } catch (err) {
-                    showError(err);
+            try {
+                body.label = label;
+                delete body.type_id;
+                if (body.crud === null) {
+                    delete body.crud;
                 }
-            } else {
-                // Send the request
-                try {
-                    await Core.editEntityPlain(_authorization, label, `${_environment.baseUrl}/app/${context.parent.parent.name}/${context.parent.parent.version}/module/${context.name}/label`)
-                    await Core.editEntity(_authorization, body, `${_environment.baseUrl}/app/${context.parent.parent.name}/${context.parent.parent.version}/module/${context.name}`)
-                    appsProvider.refresh()
-                } catch (err) {
-                    showError(err);
-                }
+                await Core.patchEntity(_authorization, body, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`)
+                appsProvider.refresh()
+            } catch (err) {
+                showError(err);
             }
         })
 
@@ -237,10 +224,7 @@ class ModuleCommands {
 
                     // There's a "Without Connection" option, so that's why there's +1
                     if (connections.length > 2) {
-                        let moduleDetail = await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`, _authorization);
-                        if (_environment.version === 2) {
-                            moduleDetail = moduleDetail.appModule
-                        }
+                        const moduleDetail = (await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`, _authorization)).appModule
                         const primaryConnectionOptions = connections;
                         let hasPrimary = !!moduleDetail.connection;
                         if (hasPrimary) {
@@ -268,20 +252,12 @@ class ModuleCommands {
                                 hasPrimary = true;
                             }
                             connection = connection.label === "--- Without connection ---" ? "" : connection.description
-                            if (_environment.version === 2) {
-                                try {
-                                    await Core.patchEntity(_authorization, {
-                                        connection: connection
-                                    }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`)
-                                } catch (err) {
-                                    showError(err);
-                                }
-                            } else {
-                                try {
-                                    await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/${context.parent.parent.version}/module/${context.name}/connection`)
-                                } catch (err) {
-                                    showError(err);
-                                }
+                            try {
+                                await Core.patchEntity(_authorization, {
+                                    connection: connection
+                                }, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`)
+                            } catch (err) {
+                                showError(err);
                             }
                         }
                         if (!hasPrimary) {
@@ -314,21 +290,12 @@ class ModuleCommands {
                         if (!Core.isFilled("connection", "module", connection)) { return }
                         if (connection.description !== "keep") {
                             connection = connection.label === "--- Without connection ---" ? "" : connection.description
-                            if (_environment.version === 2) {
-                                try {
-                                    await Core.patchEntity(_authorization, {
-                                        altConnection: connection
-                                    }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`)
-                                } catch (err) {
-                                    showError(err);
-                                }
-                            } else {
-                                try {
-                                    await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/${context.parent.parent.version}/module/${context.name}/alt_connection`)
-                                    appsProvider.refresh()
-                                } catch (err) {
-                                    showError(err);
-                                }
+                            try {
+                                await Core.patchEntity(_authorization, {
+                                    altConnection: connection
+                                }, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`)
+                            } catch (err) {
+                                showError(err);
                             }
                         }
                         break;
@@ -338,21 +305,12 @@ class ModuleCommands {
                         if (!Core.isFilled("connection", "module", connection)) { return }
                         if (connection.description !== "keep") {
                             connection = connection.label === "--- Without connection ---" ? "" : connection.description
-                            if (_environment.version === 2) {
-                                try {
-                                    await Core.patchEntity(_authorization, {
-                                        connection: connection
-                                    }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`)
-                                } catch (err) {
-                                    showError(err);
-                                }
-                            } else {
-                                try {
-                                    await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/${context.parent.parent.version}/module/${context.name}/connection`)
-                                    appsProvider.refresh()
-                                } catch (err) {
-                                    showError(err);
-                                }
+                            try {
+                                await Core.patchEntity(_authorization, {
+                                    connection: connection
+                                }, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`)
+                            } catch (err) {
+                                showError(err);
                             }
                         }
                         break;
@@ -364,21 +322,12 @@ class ModuleCommands {
                     let webhook = await vscode.window.showQuickPick(webhooks, { placeHolder: "Change webhook or keep existing." })
                     if (!Core.isFilled("webhook", "module", webhook)) { return }
                     if (webhook.description !== "keep") {
-                        if (_environment.version === 2) {
-                            try {
-                                await Core.patchEntity(_authorization, {
-                                    webhook: webhook.description
-                                }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`)
-                            } catch (err) {
-                                showError(err);
-                            }
-                        } else {
-                            try {
-                                await Core.editEntityPlain(_authorization, webhook.description, `${_environment}/app/${context.parent.parent.name}/${context.parent.parent.version}/module/${context.name}/webhook`)
-                                appsProvider.refresh()
-                            } catch (err) {
-                                showError(err);
-                            }
+                        try {
+                            await Core.patchEntity(_authorization, {
+                                webhook: webhook.description
+                            }, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`)
+                        } catch (err) {
+                            showError(err);
                         }
                     }
                     break
@@ -399,29 +348,13 @@ class ModuleCommands {
                 case 4: {
                     let newType = await vscode.window.showQuickPick(Enum.moduleTypeActionSearch, { placeHolder: "Change the type or keep existing." })
                     if (!Core.isFilled("type", "module", module)) { return }
-                    if (_environment.version === 2) {
-                        if (newType.description !== "keep") {
-                            try {
-                                await Core.patchEntity(_authorization, {
-                                    typeId: parseInt(newType.description)
-                                }, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`)
-                            } catch (err) {
-                                showError(err);
-                            }
-                        }
-                    } else {
-                        if (newType.description !== "keep") {
-                            try {
-                                await Core.editEntity(_authorization, {
-                                    label: context.bareLabel,
-                                    description: context.bareDescription,
-                                    crud: context.crud,
-                                    type_id: newType.description
-                                }, `${_environment.baseUrl}/app/${context.parent.parent.name}/${context.parent.parent.version}/module/${context.name}`)
-                                appsProvider.refresh()
-                            } catch (err) {
-                                showError(err);
-                            }
+                    if (newType.description !== "keep") {
+                        try {
+                            await Core.patchEntity(_authorization, {
+                                typeId: parseInt(newType.description)
+                            }, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`)
+                        } catch (err) {
+                            showError(err);
                         }
                     }
                     break;
@@ -440,30 +373,17 @@ class ModuleCommands {
             // If called directly (by using a command pallete) -> die
             if (!Core.contextGuard(context)) { return }
 
-            let module = await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}`, _authorization)
-            if (_environment.version === 2) {
-                module = module.appModule;
+            const module = (await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}`, _authorization)).appModule;
 
-                module.connection = module.connection ? (await Core.rpGet(`${_environment.baseUrl}/sdk/apps/connections/${module.connection}`, _authorization)).appConnection : null;
-                module.alt_connection = module.altConnection ? (await Core.rpGet(`${_environment.baseUrl}/sdk/apps/connections/${module.altConnection}`, _authorization)).appConnection : null;
-                module.webhook = module.webhook ? (await Core.rpGet(`${_environment.baseUrl}/sdk/apps/webhooks/${module.webhook}`, _authorization)).appWebhook : null;
+            module.connection = module.connection ? (await Core.rpGet(`${_environment.baseUrl}/sdk/apps/connections/${module.connection}`, _authorization)).appConnection : null;
+            module.alt_connection = module.altConnection ? (await Core.rpGet(`${_environment.baseUrl}/sdk/apps/connections/${module.altConnection}`, _authorization)).appConnection : null;
+            module.webhook = module.webhook ? (await Core.rpGet(`${_environment.baseUrl}/sdk/apps/webhooks/${module.webhook}`, _authorization)).appWebhook : null;
 
-                module.type = {
-                    id: module.typeId,
-                    label: translateModuleTypeId(module.typeId)
-                }
-                delete module.type_id;
-            } else {
-                module.connection = module.connection ? await Core.rpGet(`${_environment.baseUrl}/app/${context.parent.parent.name}/connection/${module.connection}`, _authorization) : null;
-                module.alt_connection = module.alt_connection ? await Core.rpGet(`${_environment.baseUrl}/app/${context.parent.parent.name}/connection/${module.alt_connection}`, _authorization) : null;
-                module.webhook = module.webhook ? await Core.rpGet(`${_environment.baseUrl}/app/${context.parent.parent.name}/webhook/${module.webhook}`, _authorization) : null;
-
-                module.type = {
-                    id: module.type_id,
-                    label: translateModuleTypeId(module.type_id)
-                }
-                delete module.type_id;
+            module.type = {
+                id: module.typeId,
+                label: translateModuleTypeId(module.typeId)
             }
+            delete module.type_id;
 
             const panel = vscode.window.createWebviewPanel(
                 `${context.parent.parent.name}_${context.name}_detail`,
@@ -509,7 +429,7 @@ class ModuleCommands {
                     break
                 case "Yes": {
                     // Set URI and send the request
-                    let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}/private`
+                    const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}/private`
                     try {
                         await Core.executePlain(_authorization, "", uri)
                         appsProvider.refresh()
@@ -544,7 +464,7 @@ class ModuleCommands {
                     break
                 case "Yes": {
                     // Set URI and send the request
-                    let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}/public`
+                    const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('module')}/${context.name}/public`
                     try {
                         await Core.executePlain(_authorization, "", uri)
                         appsProvider.refresh()
@@ -560,7 +480,7 @@ class ModuleCommands {
          * Clone module
          */
         vscode.commands.registerCommand('apps-sdk.module.clone', async(context) => {
-            if (!Core.envGuard(_environment, [2]) || !Core.contextGuard(context)) { return; }
+            if (!Core.contextGuard(context)) { return; }
 
             // Form Data
             const form = await Felicia([{
@@ -579,7 +499,7 @@ class ModuleCommands {
             }
 
             const app = context.parent.parent;
-            const uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, 'module')}/${context.name}/clone`
+            const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/${Core.pathDeterminer('module')}/${context.name}/clone`
             try {
                 await Core.addEntity(_authorization, form, uri);
                 appsProvider.refresh();

--- a/src/commands/RpcCommands.js
+++ b/src/commands/RpcCommands.js
@@ -39,7 +39,7 @@ class RpcCommands {
 
 			// Connection and URI compose
 			connection = connection.label === "--- Without connection ---" ? undefined : connection.description
-			let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${app.version}/${Core.pathDeterminer(_environment.version, 'rpc')}`
+			const uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${app.version}/${Core.pathDeterminer('rpc')}`
 
 			// Request
 			try {
@@ -70,24 +70,14 @@ class RpcCommands {
 			})
 			if (!Core.isFilled("label", "RPC", label)) { return }
 
-			if (_environment.version === 2) {
-				try {
-					await Core.patchEntity(_authorization, {
-						label: label
-					}, `${_environment.baseUrl}/sdk/apps/${context.parent.parent.name}/${context.parent.parent.version}/rpcs/${context.name}`)
-					appsProvider.refresh()
-				}
-				catch (err) {
-					showError(err);
-				}
-			} else {
-				try {
-					await Core.editEntityPlain(_authorization, label, `${_environment.baseUrl}/app/${context.parent.parent.name}/${context.parent.parent.version}/rpc/${context.name}/label`)
-					appsProvider.refresh()
-				}
-				catch (err) {
-					showError(err);
-				}
+			try {
+				await Core.patchEntity(_authorization, {
+					label: label
+				}, `${_environment.baseUrl}/sdk/apps/${context.parent.parent.name}/${context.parent.parent.version}/rpcs/${context.name}`)
+				appsProvider.refresh()
+			}
+			catch (err) {
+				showError(err);
 			}
 		})
 
@@ -103,12 +93,7 @@ class RpcCommands {
 			let connections = await QuickPick.connections(_environment, _authorization, context.parent.parent, true)
 
 			if (connections.length > 2) {
-				let rpcDetail = await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'rpc')}/${context.name}`, _authorization);
-
-				// ApiFlip
-				if (_environment.version === 2) {
-					rpcDetail = rpcDetail.appRpc;
-				}
+				const rpcDetail = (await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('rpc')}/${context.name}`, _authorization)).appRpc;
 
 				const primaryConnectionOptions = connections;
 				let hasPrimary = !!rpcDetail.connection;
@@ -139,22 +124,13 @@ class RpcCommands {
 						hasPrimary = true;
 					}
 					connection = connection.label === "--- Without connection ---" ? "" : connection.description
-					if (_environment.version === 2) {
-						try {
-							await Core.patchEntity(_authorization, {
-								connection: connection
-							}, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'rpc')}/${context.name}`)
-						}
-						catch (err) {
-							showError(err);
-						}
-					} else {
-						try {
-							await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/${context.parent.parent.version}/rpc/${context.name}/connection`)
-						}
-						catch (err) {
-							showError(err);
-						}
+					try {
+						await Core.patchEntity(_authorization, {
+							connection: connection
+						}, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('rpc')}/${context.name}`)
+					}
+					catch (err) {
+						showError(err);
 					}
 				}
 				if (!hasPrimary) {
@@ -190,23 +166,13 @@ class RpcCommands {
 				if (!Core.isFilled("connection", "RPC", connection)) { return }
 				if (connection.description !== "keep") {
 					connection = connection.label === "--- Don\'t use secondary connection ---" ? "" : connection.description
-					if (_environment.version === 2) {
-						try {
-							await Core.patchEntity(_authorization, {
-								altConnection: connection
-							}, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'rpc')}/${context.name}`)
-						}
-						catch (err) {
-							showError(err);
-						}
-					} else {
-						try {
-							await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/${context.parent.parent.version}/rpc/${context.name}/alt_connection`)
-							appsProvider.refresh()
-						}
-						catch (err) {
-							showError(err);
-						}
+					try {
+						await Core.patchEntity(_authorization, {
+							altConnection: connection
+						}, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('rpc')}/${context.name}`)
+					}
+					catch (err) {
+						showError(err);
 					}
 				}
 			} else {
@@ -218,13 +184,9 @@ class RpcCommands {
 				try {
 					if (connection.description !== "keep") {
 						connection = connection.label === "--- Without connection ---" ? "" : connection.description
-						if (_environment.version === 2) {
-							await Core.patchEntity(_authorization, {
-								connection: connection
-							}, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer(_environment.version, 'rpc')}/${context.name}`)
-						} else {
-							await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/${context.parent.parent.version}/rpc/${context.name}/connection`)
-						}
+						await Core.patchEntity(_authorization, {
+							connection: connection
+						}, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${context.parent.parent.name}/${context.parent.parent.version}/${Core.pathDeterminer('rpc')}/${context.name}`)
 						appsProvider.refresh()
 					}
 				}

--- a/src/commands/WebhookCommands.js
+++ b/src/commands/WebhookCommands.js
@@ -40,7 +40,7 @@ class WebhookCommands {
 			if (!Core.isFilled("connection", "webhook", connection)) { return }
 
 			// Build URI and prepare connection value
-			let uri = `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${app.name}/${Core.pathDeterminer(_environment.version, 'webhook')}`
+			let uri = `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${app.name}/${Core.pathDeterminer('webhook')}`
 			connection = connection.label === "--- Without connection ---" ? "" : connection.description
 
 			// Send the request
@@ -73,24 +73,14 @@ class WebhookCommands {
 			if (!Core.isFilled("label", "webhook", label)) { return }
 
 			// Send the request
-			if (_environment.version === 2) {
-				try {
-					await Core.patchEntity(_authorization, {
-						label: label
-					}, `${_environment.baseUrl}/sdk/apps/webhooks/${context.name}`)
-					appsProvider.refresh()
-				}
-				catch (err) {
-					showError(err)
-				}
-			} else {
-				try {
-					await Core.editEntityPlain(_authorization, label, `${_environment.baseUrl}/app/${context.parent.parent.name}/webhook/${context.name}/label`)
-					appsProvider.refresh()
-				}
-				catch (err) {
-					showError(err);
-				}
+			try {
+				await Core.patchEntity(_authorization, {
+					label: label
+				}, `${_environment.baseUrl}/sdk/apps/webhooks/${context.name}`)
+				appsProvider.refresh()
+			}
+			catch (err) {
+				showError(err)
 			}
 		})
 
@@ -124,12 +114,7 @@ class WebhookCommands {
 			}
 
 			if (multi) {
-				let webhookDetail = await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${_environment.version === 2 ? '' : `${context.parent.parent.name}/`}${Core.pathDeterminer(_environment.version, 'webhook')}/${context.name}`, _authorization);
-
-				// ApiFlip
-				if (_environment.version === 2) {
-					webhookDetail = webhookDetail.appWebhook;
-				}
+				const webhookDetail = (await Core.rpGet(`${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.pathDeterminer('webhook')}/${context.name}`, _authorization)).appWebhook;
 
 				const primaryConnectionOptions = connections;
 
@@ -160,22 +145,13 @@ class WebhookCommands {
 						hasPrimary = true;
 					}
 					connection = connection.label === "--- Without connection ---" ? "" : connection.description
-					if (_environment.version === 2) {
-						try {
-							await Core.patchEntity(_authorization, {
-								connection: connection
-							}, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.pathDeterminer(_environment.version, 'webhook')}/${context.name}`)
-						}
-						catch (err) {
-							showError(err);
-						}
-					} else {
-						try {
-							await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/webhook/${context.name}/connection`)
-						}
-						catch (err) {
-							showError(err);
-						}
+					try {
+						await Core.patchEntity(_authorization, {
+							connection: connection
+						}, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.pathDeterminer('webhook')}/${context.name}`)
+					}
+					catch (err) {
+						showError(err);
 					}
 				}
 				if (!hasPrimary) {
@@ -213,23 +189,13 @@ class WebhookCommands {
 				if (!Core.isFilled("connection", "webhook", connection)) { return }
 				if (connection.description !== "keep") {
 					connection = connection.label === "--- Don\'t use secondary connection ---" ? "" : connection.description
-					if (_environment.version === 2) {
-						try {
-							await Core.patchEntity(_authorization, {
-								altConnection: connection
-							}, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.pathDeterminer(_environment.version, 'webhook')}/${context.name}`)
-						}
-						catch (err) {
-							showError(err);
-						}
-					} else {
-						try {
-							await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/webhook/${context.name}/alt_connection`)
-							appsProvider.refresh()
-						}
-						catch (err) {
-							showError(err);
-						}
+					try {
+						await Core.patchEntity(_authorization, {
+							altConnection: connection
+						}, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.pathDeterminer('webhook')}/${context.name}`)
+					}
+					catch (err) {
+						showError(err);
 					}
 				}
 			} else {
@@ -243,13 +209,9 @@ class WebhookCommands {
 				try {
 					if (connection.description !== "keep") {
 						connection = connection.label === "--- Without connection ---" ? "" : connection.description
-						if (_environment.version === 2) {
-							await Core.patchEntity(_authorization, {
-								connection: connection
-							}, `${_environment.baseUrl}/${Core.pathDeterminer(_environment.version, '__sdk')}${Core.pathDeterminer(_environment.version, 'app')}/${Core.pathDeterminer(_environment.version, 'webhook')}/${context.name}`)
-						} else {
-							await Core.editEntityPlain(_authorization, connection, `${_environment}/app/${context.parent.parent.name}/webhook/${context.name}/connection`)
-						}
+						await Core.patchEntity(_authorization, {
+							connection: connection
+						}, `${_environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${Core.pathDeterminer('webhook')}/${context.name}`)
 						appsProvider.refresh()
 					}
 				}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,23 +155,13 @@ export async function activate(context: vscode.ExtensionContext) {
 		// Else -> the environment is set and it contains API key -> set (pseudo)global variables and continue
 		else {
 			_authorization = 'Token ' + currentEnvironment.apikey;
-			// If API version not set or it's 1
-			if (!currentEnvironment.version || currentEnvironment.version === 1) {
-				_environment = {
-					baseUrl: `https://${currentEnvironment.url}/v1`,
-					version: 1,
-				};
-			} else {
-				// API V2 and development purposes
-				// configuration.unsafe removes https
-				// configuration.noVersionPath removes vX in path
-				_environment = {
-					baseUrl: `http${currentEnvironment.unsafe === true ? '' : 's'}://${currentEnvironment.url}${
-						currentEnvironment.noVersionPath === true ? '' : `/v${currentEnvironment.version}`
-					}${currentEnvironment.admin === true ? '/admin' : ''}`,
-					version: currentEnvironment.version,
-				};
-			}
+			// configuration.unsafe removes https
+			// configuration.noVersionPath removes vX in path
+			_environment = {
+				baseUrl: `http${currentEnvironment.unsafe === true ? '' : 's'}://${currentEnvironment.url}${
+					currentEnvironment.noVersionPath === true ? '' : `/v${currentEnvironment.version}`
+				}${currentEnvironment.admin === true ? '/admin' : ''}`,
+			};
 			_admin = currentEnvironment.admin === true;
 		}
 	}
@@ -352,7 +342,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// ensure it gets properly disposed. Upon disposal the events will be flushed
 	context.subscriptions.push(telemetryReporter);
-	sendTelemetry('activated', { version: _environment.version });
+	sendTelemetry('activated', { version: 2 });
 
 	log('info', 'Extension fully activated with environment ' + _environment.baseUrl);
 }

--- a/src/libs/app-icon.ts
+++ b/src/libs/app-icon.ts
@@ -38,15 +38,7 @@ export async function downloadAndStoreAppIcon(
 						Authorization: apiAuthorization,
 						'imt-apps-sdk-version': Meta.version,
 					},
-					url: (() => {
-						switch (environment.version) {
-							case 2:
-								return `${apiBaseUrl}/sdk/apps/${app.name}/${app.version}/icon/512`;
-							case 1:
-							default:
-								return `${apiBaseUrl}/app/${app.name}/${app.version}/icon/512`;
-						}
-					})(),
+					url: `${apiBaseUrl}/sdk/apps/${app.name}/${app.version}/icon/512`,
 					dest: iconLocalPath.dark,
 				});
 			} catch (_err: any) {

--- a/src/providers/AppsProvider.js
+++ b/src/providers/AppsProvider.js
@@ -84,20 +84,11 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		 */
 		if (element === undefined) {
 			//#region Get apps list
-			let response;
-			switch (this._environment.version) {
-				case 2:
-					response = (await Core.rpGet(`${this._environment.baseUrl}/sdk/apps`, this._authorization, {
-						'cols[]': [
-							'name', 'label', 'description', 'version', 'beta', 'theme', 'public', 'approved', 'changes'
-						]
-					})).apps
-					break;
-				case 1:
-				default:
-					response = await Core.rpGet(`${this._baseUrl}/app`, this._authorization)
-					break;
-			}
+			const response = (await Core.rpGet(`${this._environment.baseUrl}/sdk/apps`, this._authorization, {
+				'cols[]': [
+					'name', 'label', 'description', 'version', 'beta', 'theme', 'public', 'approved', 'changes'
+				]
+			})).apps
 			if (response === undefined) { return }
 			//#endregion Get apps list
 
@@ -128,8 +119,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 				[`modules`, "Modules"],
 				[`rpcs`, "Remote procedures"],
 				[`functions`, "Functions"],
-				// Endpoints exist in API v2 only.
-				...(this._environment.version === 2 ? [[`endpoints`, "Endpoints"]] : []),
+				[`endpoints`, "Endpoints"],
 				[`docs`, "Docs"]
 			].map(group => {
 
@@ -164,7 +154,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 					return change
 				}
 			})
-			output.push(new Code('groups', 'Groups', element, "imljson", Core.pathDeterminer(this._environment.version, 'app'), false, groupChange ? groupChange.id : null));
+			output.push(new Code('groups', 'Groups', element, "imljson", Core.pathDeterminer('app'), false, groupChange ? groupChange.id : null));
 			return output;
 		}
 		/*
@@ -183,14 +173,14 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 							return change
 						}
 					})
-					return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'app'), false, change ? change.id : null, code[2])
+					return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('app'), false, change ? change.id : null, code[2])
 				})
 			}
 
 			// Docs
 			else if (element.contextValue === "docs") {
 				return [
-					new Code(`readme`, "Readme", element, "md", Core.pathDeterminer(this._environment.version, 'app')),
+					new Code(`readme`, "Readme", element, "md", Core.pathDeterminer('app')),
 					//new Code(`images`, "Images", element, "img")
 				]
 			}
@@ -202,8 +192,8 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 					if (element.id.includes(`_${needle}`)) {
 						const componentType = needle.slice(0, -1);
 						const uri = ["connection", "webhook"].includes(componentType) ?
-							`${this._baseUrl}/${Core.pathDeterminer(this._environment.version, '__sdk')}${Core.pathDeterminer(this._environment.version, 'app')}/${element.parent.name}/${Core.pathDeterminer(this._environment.version, componentType)}` :
-							`${this._baseUrl}/${Core.pathDeterminer(this._environment.version, '__sdk')}${Core.pathDeterminer(this._environment.version, 'app')}/${element.parent.name}/${element.parent.version}/${Core.pathDeterminer(this._environment.version, componentType)}`
+							`${this._baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${element.parent.name}/${Core.pathDeterminer(componentType)}` :
+							`${this._baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${element.parent.name}/${element.parent.version}/${Core.pathDeterminer(componentType)}`
 						let response
 						try {
 							// For endpoints, suppress the error dialog: the feature may be disabled on the
@@ -215,7 +205,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 							}
 							throw err
 						}
-						const items = this._environment.version === 1 ? response : response[camelCase(`app_${needle}`)];
+						const items = response[camelCase(`app_${needle}`)];
 						return items.map(item => {
 							const changes = element.changes.filter(change => {
 								if (change.item === item.name) {
@@ -249,7 +239,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 								}
 							})
 						}
-						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'connection'), false, change ? change.id : null, code[2])
+						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('connection'), false, change ? change.id : null, code[2])
 					})
 				case "webhook":
 					return [
@@ -260,7 +250,6 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 						[`update`, "Update", "Describes the API call to be performed when the webhook is updated. Leave empty when there's no such call. This specification does inherit from base."],
 						[`scope`, "Required scope", "Scope required by this webhook. Array of strings."]
 					].flatMap(code => {
-						if (code[0] === 'update' && this._environment.version === 1) return [];
 						let change
 						if (element.changes) {
 							change = element.changes.find(change => {
@@ -269,7 +258,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 								}
 							})
 						}
-						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'webhook'), false, change ? change.id : null, code[2])
+						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('webhook'), false, change ? change.id : null, code[2])
 					})
 				case "module":
 					switch (element.type) {
@@ -293,7 +282,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 										}
 									})
 								}
-								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), false, change ? change.id : null, code[2])
+								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('module'), false, change ? change.id : null, code[2])
 							})
 						// Trigger
 						case 1:
@@ -313,7 +302,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 										}
 									})
 								}
-								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), false, change ? change.id : null, code[2])
+								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('module'), false, change ? change.id : null, code[2])
 							})
 						// Instant trigger
 						case 10:
@@ -331,7 +320,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 										}
 									})
 								}
-								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), false, change ? change.id : null, code[2])
+								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('module'), false, change ? change.id : null, code[2])
 							})
 						// Responder
 						case 11:
@@ -348,7 +337,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 										}
 									})
 								}
-								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), false, change ? change.id : null, code[2])
+								return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('module'), false, change ? change.id : null, code[2])
 							})
 						default:
 							throw new Error(`Unknown or unsupported module type "${element.type}".`);
@@ -366,7 +355,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 								}
 							})
 						}
-						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'rpc'), false, change ? change.id : null, code[2])
+						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('rpc'), false, change ? change.id : null, code[2])
 					})
 				case "function":
 					return [
@@ -381,7 +370,7 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 								}
 							})
 						}
-						return new Code(code[0], code[1], element, "js", Core.pathDeterminer(this._environment.version, 'function'), false, change ? change.id : null, code[2])
+						return new Code(code[0], code[1], element, "js", Core.pathDeterminer('function'), false, change ? change.id : null, code[2])
 					})
 				case "endpoint": {
 					const findChange = (codeName) => (element.changes ? element.changes.find(change => change.code == codeName) : undefined);
@@ -392,11 +381,11 @@ class AppsProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 						[`scope`, "Required scope", "Scope required by this endpoint. Array of strings."]
 					].map(code => {
 						const change = findChange(code[0]);
-						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer(this._environment.version, 'endpoint'), false, change ? change.id : null, code[2])
+						return new Code(code[0], code[1], element, "imljson", Core.pathDeterminer('endpoint'), false, change ? change.id : null, code[2])
 					});
 					// `context` is editable as a markdown source (metadata-backed; see component-code-def.ts).
 					const contextChange = findChange('context');
-					endpointCodes.push(new Code(`context`, "Context", element, "md", Core.pathDeterminer(this._environment.version, 'endpoint'), false, contextChange ? contextChange.id : null, "Context for AI agents on how to use this endpoint. Editable as a markdown source."));
+					endpointCodes.push(new Code(`context`, "Context", element, "md", Core.pathDeterminer('endpoint'), false, contextChange ? contextChange.id : null, "Context for AI agents on how to use this endpoint. Editable as a markdown source."));
 					return endpointCodes;
 				}
 			}

--- a/src/providers/AppsProvider.test.ts
+++ b/src/providers/AppsProvider.test.ts
@@ -10,7 +10,7 @@ import App from '../tree/App';
  * search feature without requiring a live Make environment.
  */
 suite('AppsProvider search filter', () => {
-	const environment = { baseUrl: 'https://example.com', version: 2 } as any;
+	const environment = { baseUrl: 'https://example.com' } as any;
 
 	function createProvider() {
 		return new (AppsProvider as any)('Token abc', environment, '/tmp/apps-sdk-test', false);
@@ -72,7 +72,7 @@ suite('AppsProvider search filter', () => {
  * matching against label, name (id), and description case-insensitively.
  */
 suite('AppsProvider _applySearchFilter()', () => {
-	const environment = { baseUrl: 'https://example.com', version: 2 } as any;
+	const environment = { baseUrl: 'https://example.com' } as any;
 
 	// Real App instances so the test also guards the App shape (bareLabel/name/description)
 	// that the filter depends on. Note: App defaults a missing description to '' (see src/tree/App.js).

--- a/src/providers/OpensourceProvider.js
+++ b/src/providers/OpensourceProvider.js
@@ -45,22 +45,13 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 		 * LEVEL 0 - APPS
 		 */
 		if (element === undefined) {
-			let response;
-			switch (this._environment.version) {
-				case 2:
-					// ! opensource filter is not available on admin endpoint
-					response = (await Core.rpGet(`${this._environment.baseUrl.replace('/admin', '')}/sdk/apps`, this._authorization, {
-						opensource: true,
-						'cols[]': [
-							'name', 'label', 'description', 'version', 'beta', 'theme', 'public', 'approved', 'changes'
-						]
-					})).apps
-					break;
-				case 1:
-				default:
-					response = await Core.rpGet(`${this._baseUrl}/app`, this._authorization, { opensource: true })
-					break;
-			}
+			// ! opensource filter is not available on admin endpoint
+			const response = (await Core.rpGet(`${this._environment.baseUrl.replace('/admin', '')}/sdk/apps`, this._authorization, {
+				opensource: true,
+				'cols[]': [
+					'name', 'label', 'description', 'version', 'beta', 'theme', 'public', 'approved', 'changes'
+				]
+			})).apps
 			if (response === undefined) { return }
 
 			const apps = response.map((app) => {
@@ -86,8 +77,7 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 				new Group(`modules`, "Modules", element),
 				new Group(`rpcs`, "Remote procedures", element),
 				new Group(`functions`, "IML functions", element),
-				// Endpoints exist in API v2 only.
-				...(this._environment.version === 2 ? [new Group(`endpoints`, "Endpoints", element)] : []),
+				new Group(`endpoints`, "Endpoints", element),
 				new Group(`docs`, "Docs", element)
 			]
 		}
@@ -98,14 +88,14 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			// General
 			if (element.id.includes("general")) {
 				return [
-					new Code(`base`, "Base", element, "imljson", Core.pathDeterminer(this._environment.version, 'app'), true),
-					new Code(`common`, "Common", element, "imljson", Core.pathDeterminer(this._environment.version, 'app'), true)
+					new Code(`base`, "Base", element, "imljson", Core.pathDeterminer('app'), true),
+					new Code(`common`, "Common", element, "imljson", Core.pathDeterminer('app'), true)
 				]
 			}
 			// Docs
 			else if (element.id.includes("docs")) {
 				return [
-					new Code(`readme`, "Readme", element, "md", Core.pathDeterminer(this._environment.version, 'app'), true),
+					new Code(`readme`, "Readme", element, "md", Core.pathDeterminer('app'), true),
 					//new Code(`images`, "Images", element, "img", true)
 				]
 			}
@@ -115,8 +105,8 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 					if (element.id.includes(needle)) {
 						let name = needle.slice(0, -1);
 						let uri = ["connection", "webhook"].includes(name) ?
-							`${this._baseUrl}/${Core.pathDeterminer(this._environment.version, '__sdk')}${Core.pathDeterminer(this._environment.version, 'app')}/${element.parent.name}/${Core.pathDeterminer(this._environment.version, name)}` :
-							`${this._baseUrl}/${Core.pathDeterminer(this._environment.version, '__sdk')}${Core.pathDeterminer(this._environment.version, 'app')}/${element.parent.name}/${element.parent.version}/${Core.pathDeterminer(this._environment.version, name)}`
+							`${this._baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${element.parent.name}/${Core.pathDeterminer(name)}` :
+							`${this._baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}/${element.parent.name}/${element.parent.version}/${Core.pathDeterminer(name)}`
 						let response
 						try {
 							// For endpoints, suppress the error dialog: the feature may be disabled on the
@@ -128,7 +118,7 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 							}
 							throw err
 						}
-						const items = this._environment.version === 1 ? response : response[camelCase(`app_${needle}`)];
+						const items = response[camelCase(`app_${needle}`)];
 						return items.map(item => new Item(item.name, item.label || (item.name + item.args), element, name, item.type || item.type_id || item.typeId, item.public, item.approved))
 					}
 				}
@@ -141,23 +131,21 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 			switch (element.supertype) {
 				case "connection":
 					return [
-						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'connection'), true),
-						new Code(`common`, "Common data", element, "imljson", Core.pathDeterminer(this._environment.version, 'connection'), true),
-						new Code(`scopes`, "Scope list", element, "imljson", Core.pathDeterminer(this._environment.version, 'connection'), true),
-						new Code(`scope`, "Default scope", element, "imljson", Core.pathDeterminer(this._environment.version, 'connection'), true),
-						new Code(`parameters`, "Parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'connection'), true)
+						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('connection'), true),
+						new Code(`common`, "Common data", element, "imljson", Core.pathDeterminer('connection'), true),
+						new Code(`scopes`, "Scope list", element, "imljson", Core.pathDeterminer('connection'), true),
+						new Code(`scope`, "Default scope", element, "imljson", Core.pathDeterminer('connection'), true),
+						new Code(`parameters`, "Parameters", element, "imljson", Core.pathDeterminer('connection'), true)
 					]
 				case "webhook": {
 					const out = [
-						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'webhook'), true),
-						new Code(`parameters`, "Parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'webhook'), true),
-						new Code(`attach`, "Attach", element, "imljson", Core.pathDeterminer(this._environment.version, 'webhook'), true),
-						new Code(`detach`, "Detach", element, "imljson", Core.pathDeterminer(this._environment.version, 'webhook'), true),
-						new Code(`scope`, "Required scope", element, "imljson", Core.pathDeterminer(this._environment.version, 'webhook'), true),
+						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('webhook'), true),
+						new Code(`parameters`, "Parameters", element, "imljson", Core.pathDeterminer('webhook'), true),
+						new Code(`attach`, "Attach", element, "imljson", Core.pathDeterminer('webhook'), true),
+						new Code(`detach`, "Detach", element, "imljson", Core.pathDeterminer('webhook'), true),
+						new Code(`scope`, "Required scope", element, "imljson", Core.pathDeterminer('webhook'), true),
+						new Code(`update`, "Update", element, "imljson", Core.pathDeterminer('webhook'), true),
 					];
-					if (this._environment.version === 2) {
-						out.push(new Code(`update`, "Update", element, "imljson", Core.pathDeterminer(this._environment.version, 'webhook'), true));
-					}
 					return out;
 				}
 				case "module":
@@ -166,58 +154,58 @@ class OpensourceProvider /* implements vscode.TreeDataProvider<Dependency> */ {
 						case 4:
 						case 9:
 							return [
-								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`expect`, "Mappable parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`interface`, "Interface", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`samples`, "Samples", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`scope`, "Scope", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
+								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`expect`, "Mappable parameters", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`interface`, "Interface", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`samples`, "Samples", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`scope`, "Scope", element, "imljson", Core.pathDeterminer('module'), true),
 							]
 						// Trigger
 						case 1:
 							return [
-								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`epoch`, "Epoch", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`interface`, "Interface", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`samples`, "Samples", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`scope`, "Scope", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
+								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`epoch`, "Epoch", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`interface`, "Interface", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`samples`, "Samples", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`scope`, "Scope", element, "imljson", Core.pathDeterminer('module'), true),
 							]
 						// Instant trigger
 						case 10:
 							return [
-								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`expect`, "Interface", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`samples`, "Samples", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true)
+								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`expect`, "Interface", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`samples`, "Samples", element, "imljson", Core.pathDeterminer('module'), true)
 							]
 						// Responder
 						case 11:
 							return [
-								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true),
-								new Code(`expect`, "Mappable parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'module'), true)
+								new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`parameters`, "Static parameters", element, "imljson", Core.pathDeterminer('module'), true),
+								new Code(`expect`, "Mappable parameters", element, "imljson", Core.pathDeterminer('module'), true)
 							]
 					}
 					break;
 				case "rpc":
 					return [
-						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'rpc'), true),
-						new Code(`parameters`, "Parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'rpc'), true)
+						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('rpc'), true),
+						new Code(`parameters`, "Parameters", element, "imljson", Core.pathDeterminer('rpc'), true)
 					]
 				case "function":
 					return [
-						new Code(`code`, "Code", element, "js", Core.pathDeterminer(this._environment.version, 'function'), true)
+						new Code(`code`, "Code", element, "js", Core.pathDeterminer('function'), true)
 					]
 				case "endpoint":
 					// Note: code names must match the endpoint section URL segments used by the API.
 					// `context` is a markdown source (metadata-backed), like the app readme.
 					return [
-						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer(this._environment.version, 'endpoint'), true),
-						new Code(`inputParameters`, "Input parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'endpoint'), true),
-						new Code(`outputParameters`, "Output parameters", element, "imljson", Core.pathDeterminer(this._environment.version, 'endpoint'), true),
-						new Code(`scope`, "Required scope", element, "imljson", Core.pathDeterminer(this._environment.version, 'endpoint'), true),
-						new Code(`context`, "Context", element, "md", Core.pathDeterminer(this._environment.version, 'endpoint'), true)
+						new Code(`api`, "Communication", element, "imljson", Core.pathDeterminer('endpoint'), true),
+						new Code(`inputParameters`, "Input parameters", element, "imljson", Core.pathDeterminer('endpoint'), true),
+						new Code(`outputParameters`, "Output parameters", element, "imljson", Core.pathDeterminer('endpoint'), true),
+						new Code(`scope`, "Required scope", element, "imljson", Core.pathDeterminer('endpoint'), true),
+						new Code(`context`, "Context", element, "md", Core.pathDeterminer('endpoint'), true)
 					]
 			}
 		}

--- a/src/providers/ParametersProvider.ts
+++ b/src/providers/ParametersProvider.ts
@@ -27,7 +27,7 @@ export class ParametersProvider {
 	async loadParameters(crumbs: string[], version: string) {
 
 		// Preparing api route
-		let urn = `/${Core.pathDeterminer(this._environment.version, '__sdk')}${Core.pathDeterminer(this._environment.version, 'app')}`;
+		let urn = `/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer('app')}`;
 		if (Core.isVersionable(crumbs[3])) {
 			urn += `/${crumbs[2]}/${version}`;
 		}

--- a/src/providers/configuration.ts
+++ b/src/providers/configuration.ts
@@ -35,7 +35,8 @@ export interface AppsSdkConfigurationEnvironment {
  * User can define multiple environmnents.
  * Function returns the one that is currently selected by user.
  *
- * @throws {Error} If no environment is selected or if selected environment is not found in the configuration.
+ * @throws {Error} If no environment is selected, if selected environment is not found in the configuration,
+ *                 or if the selected environment is not using API v2.
  */
 export function getCurrentEnvironment(): AppsSdkConfigurationEnvironment {
 	const _configuration = getConfiguration();
@@ -48,6 +49,12 @@ export function getCurrentEnvironment(): AppsSdkConfigurationEnvironment {
 	const selectedEnvironment = environments.find((e: any) => e.uuid === _configuration.environment);
 	if (!selectedEnvironment) {
 		throw new Error("Selected environment ('apps-sdk.environment') not found in 'apps-sdk.environments'. Check your configuration.");
+	}
+	if (selectedEnvironment.version !== 2) {
+		throw new Error(
+			`Environment "${selectedEnvironment.name}" uses unsupported API v${selectedEnvironment.version ?? '(not set)'}. ` +
+				'Only Make API v2 is supported — please update this environment\'s version, or add a new one.',
+		);
 	}
 	return selectedEnvironment;
 }

--- a/src/services/imljson-schema-associations.test.ts
+++ b/src/services/imljson-schema-associations.test.ts
@@ -4,10 +4,13 @@ import proxyquire from 'proxyquire';
 import type * as vscode from 'vscode';
 
 /**
- * Regression coverage for the app-major-version vs. API-version mixup: `Core.pathDeterminer` must be
- * called with the *API* version (always 2 here, per the `environment.version !== 2` guard), not the
- * app's own major version parsed out of the temp file path — otherwise the fetch URL degenerates to the
- * v1 shape for any app whose major version isn't coincidentally 2 (e.g. every version-1 app).
+ * Regression coverage for `fetchEndpoints`'s URL construction. This used to guard against an API-version
+ * vs. app-major-version mixup (`Core.pathDeterminer` took an API-version argument that was easy to
+ * confuse with the app's own major version parsed out of the temp file path); that class of bug is now
+ * structurally impossible since `pathDeterminer` dropped its version argument and always returns its
+ * fixed v2 segment names (`sdk`, `apps`, `endpoints`, ...). What's left to protect is `parseAppAndVersion`:
+ * it must still pull the app's own major version out of the temp file path and place it correctly in the
+ * URL's version segment.
  */
 function loadModuleWithMockedCore(rpGet: (url: string, ...rest: unknown[]) => Promise<unknown>) {
 	return proxyquire('./imljson-schema-associations', {
@@ -20,7 +23,7 @@ function createEditorForFile(fileName: string): vscode.TextEditor {
 }
 
 suite('ImljsonSchemaAssociations', () => {
-	test("fetches endpoints using the API version, not the app's own major version", async () => {
+	test("fetches endpoints using the app's own major version parsed from the temp file path", async () => {
 		let requestedUrl: string | undefined;
 		const mod = loadModuleWithMockedCore(async (url: string) => {
 			requestedUrl = url;
@@ -33,9 +36,9 @@ suite('ImljsonSchemaAssociations', () => {
 				sendNotification: async (_type: unknown, payload: unknown) => sentNotifications.push(payload),
 			} as any,
 			authorization: 'Token test',
-			// The app in the file path below is major version 1 — a real app on API v2 whose own
-			// version number happens to differ from the API version (the bug's exact failure case).
-			environment: { baseUrl: 'https://example.make.com/v2', version: 2 },
+			// The app in the file path below is major version 1 — it must land in the URL's version
+			// segment as-is, not get conflated with anything else `pathDeterminer` produces.
+			environment: { baseUrl: 'https://example.make.com/v2' },
 		});
 
 		await associations.handleActiveEditorChange(
@@ -56,7 +59,7 @@ suite('ImljsonSchemaAssociations', () => {
 		const associations = new mod.ImljsonSchemaAssociations({
 			client: { sendNotification: async () => undefined } as any,
 			authorization: 'Token test',
-			environment: { baseUrl: 'https://example.make.com/v2', version: 2 },
+			environment: { baseUrl: 'https://example.make.com/v2' },
 		});
 
 		// Connections/webhooks are non-versionable (`Core.isVersionable`), so their temp paths have no

--- a/src/services/imljson-schema-associations.ts
+++ b/src/services/imljson-schema-associations.ts
@@ -170,7 +170,7 @@ export class ImljsonSchemaAssociations {
 	/**
 	 * Re-evaluates Endpoint enrichment for the newly active editor. A no-op unless the editor is an
 	 * online-mode `api.imljson`/`publish.imljson` file (as opposed to a local-dev workspace file, or e.g.
-	 * a version-less connection/webhook file) on API v2.
+	 * a version-less connection/webhook file).
 	 */
 	async handleActiveEditorChange(editor: vscode.TextEditor | undefined): Promise<void> {
 		try {
@@ -181,7 +181,7 @@ export class ImljsonSchemaAssociations {
 	}
 
 	private async refreshForEditor(editor: vscode.TextEditor | undefined): Promise<void> {
-		if (!editor || this.environment.version !== 2) {
+		if (!editor) {
 			return;
 		}
 
@@ -235,14 +235,9 @@ export class ImljsonSchemaAssociations {
 
 	private async fetchEndpoints(app: string, version: number): Promise<SdkEndpointSchemaInfo[] | null> {
 		try {
-			// `Core.pathDeterminer` switches on the *API* version (this.environment.version, always 2 here —
-			// see the guard in refreshForEditor), not the app's own major `version`, which only belongs in
-			// the URL path segment itself (see EndpointCommands.endpointsCollectionUrl for the same shape).
-			const apiVersion = this.environment.version;
-			const url = `${this.environment.baseUrl}/${Core.pathDeterminer(apiVersion, '__sdk')}${Core.pathDeterminer(
-				apiVersion,
+			const url = `${this.environment.baseUrl}/${Core.pathDeterminer('__sdk')}${Core.pathDeterminer(
 				'app',
-			)}/${app}/${version}/${Core.pathDeterminer(apiVersion, 'endpoint')}`;
+			)}/${app}/${version}/${Core.pathDeterminer('endpoint')}`;
 			const response = await Core.rpGet(url, this.authorization, { includeInputSchema: true }, true);
 			const appEndpoints: unknown = response?.appEndpoints;
 			if (!Array.isArray(appEndpoints)) {

--- a/src/types/environment.types.ts
+++ b/src/types/environment.types.ts
@@ -1,4 +1,6 @@
+/**
+ * Represents the instance of Make.com - EU1, US1, or other public or private.
+ */
 export interface Environment {
 	baseUrl: string;
-	version: number
 }


### PR DESCRIPTION
## Summary

The codebase was riddled with `if (environment.version === 2) { ... } else { ... }` branches distinguishing the legacy Integromat API (v1) from the current Make API (v2). API v1 has been dead for a long time, so this PR removes all v1-only code paths and keeps only the v2 behavior.

- Centralizes environment-version validation into a single fail-point: `getCurrentEnvironment()` in `src/providers/configuration.ts` — any environment still configured for API v1 now fails clearly with a helpful error instead of running through dead branches.
- Simplifies the `Environment` type (drops the `version` field), `Core.pathDeterminer()` (now a fixed v2-only segment mapping), and removes `Core.envGuard()` entirely.
- Simplifies ZIP app import/export to always use the v2 archive format (drops the legacy v1 archive shape). The `.sdk` marker is kept — import now uses it to detect and reject legacy v1 archives with a clear error instead of silently mis-parsing them.
- Collapses every component command/provider file (`AppCommands`, `ModuleCommands`, `RpcCommands`, `WebhookCommands`, `ConnectionCommands`, `AccountCommands`, `AppsProvider`, `OpensourceProvider`, `QuickPick`, `CoreCommands`, `FunctionCommands`, `EndpointCommands`, etc.) to their v2-only code path.

Jira: https://make.atlassian.net/browse/PLAT-1079

---
Written by 🤖 Claude Code AI, reviewed by @ma-zal